### PR TITLE
Add route53 domain expiry in 7 days test

### DIFF
--- a/src/auto-posture-evaluator/testers/route53_tester.py
+++ b/src/auto-posture-evaluator/testers/route53_tester.py
@@ -17,6 +17,7 @@ class Tester(interfaces.TesterInterface):
         self.account_arn = boto3.client('sts').get_caller_identity().get('Arn')
         self.account_id = boto3.client('sts').get_caller_identity().get('Account')
         self.aws_route53_domain_client = boto3.client('route53domains')
+        self.route53_domains = self._get_all_route53_domains()
 
     def declare_tested_service(self) -> str:
         return 'route53'
@@ -95,6 +96,16 @@ class Tester(interfaces.TesterInterface):
                     })
 
         return result
+
+    def _get_all_route53_domains(self):
+        domains = []
+        paginator = self.aws_route53_domain_client.get_paginator('list_domains')
+        response_iterator = paginator.paginate()
+
+        for page in response_iterator:
+            domains.extend(page['Domains'])
+        
+        return domains
 
     def route53_domain_expiry_in_7_days(self):
         result = []

--- a/src/auto-posture-evaluator/testers/route53_tester.py
+++ b/src/auto-posture-evaluator/testers/route53_tester.py
@@ -31,7 +31,8 @@ class Tester(interfaces.TesterInterface):
                 self.detect_dangling_dns_records() + \
                 self.route53_domain_expiry_in_7_days() + \
                 self.detect_domain_is_not_locked_for_transfer() + \
-                self.detect_domain_auto_renewal_disabled()
+                self.detect_domain_auto_renewal_disabled() + \
+                self.detect_domain_expired()
         else:
             raise Exception("No Route53 data could be retrieved.")
 
@@ -212,4 +213,40 @@ class Tester(interfaces.TesterInterface):
                     "timestamp": time.time(),
                     "test_result": "issue_found" 
                 })
+        return result
+
+    def detect_domain_expired(self):
+        result = []
+        test_name = "domain_expired"
+
+        domains = self.route53_domains
+
+        for domain in domains:
+            domain_name = domain['DomainName']
+            expiry = domain['Expiry']
+            current_date = datetime.now(tz=dt.timezone.utc)
+
+            if expiry <= current_date:
+                result.append({
+                    "user": self.user_id,
+                    "account_arn": self.account_arn,
+                    "account": self.account_id,
+                    "test_name": test_name,
+                    "item": domain_name,
+                    "item_type": "domain_name",
+                    "timestamp": time.time(),
+                    "test_result": "issue_found" 
+                })
+            else:
+                result.append({
+                    "user": self.user_id,
+                    "account_arn": self.account_arn,
+                    "account": self.account_id,
+                    "test_name": test_name,
+                    "item": domain_name,
+                    "item_type": "domain_name",
+                    "timestamp": time.time(),
+                    "test_result": "no_issue_found" 
+                })
+        
         return result

--- a/src/auto-posture-evaluator/testers/route53_tester.py
+++ b/src/auto-posture-evaluator/testers/route53_tester.py
@@ -40,6 +40,7 @@ class Tester(interfaces.TesterInterface):
 
     def detect_dangling_dns_records(self):
         result = []
+        test_name = "aws_route53_dangling_dns_records"
         # Filtering the list to get the list of public zones only
         public_zones = [zone for zone in self.hosted_zones['HostedZones'] if not zone['Config']['PrivateZone']]
         for cur_zone in public_zones:
@@ -80,7 +81,7 @@ class Tester(interfaces.TesterInterface):
                             "item_type": "dns_record",
                             "dns_record": record_name,
                             "record": record,
-                            "test_name": 'dangling_dns_records',
+                            "test_name": test_name,
                             "dangling_ip": dangling_ip_address,
                             "zone": cur_zone["Id"],
                             "timestamp": time.time(),
@@ -91,7 +92,7 @@ class Tester(interfaces.TesterInterface):
                         "user": self.user_id,
                         "account_arn": self.account_arn,
                         "account": self.account_id,
-                        "test_name": 'dangling_dns_records',
+                        "test_name": test_name,
                         "item": record_name,
                         "item_type": "dns_record",
                         "record": record,
@@ -113,7 +114,7 @@ class Tester(interfaces.TesterInterface):
 
     def route53_domain_expiry_in_7_days(self):
         result = []
-        test_name = "route53_domain_expiry_in_7_days"
+        test_name = "aws_route53_domain_expiry_in_7_days"
 
         domains = self.route53_domains
 
@@ -150,7 +151,7 @@ class Tester(interfaces.TesterInterface):
 
     def detect_domain_is_not_locked_for_transfer(self):
         result = []
-        test_name = "domain_is_not_locked_for_transfer"
+        test_name = "aws_route53_domain_is_not_locked_for_transfer"
 
         domains = self.route53_domains
 
@@ -185,7 +186,7 @@ class Tester(interfaces.TesterInterface):
 
     def detect_domain_auto_renewal_disabled(self):
         result = []
-        test_name = "domain_auto_renewal_disabled"
+        test_name = "aws_route53_domain_auto_renewal_disabled"
 
         domains = self.route53_domains
 
@@ -219,7 +220,7 @@ class Tester(interfaces.TesterInterface):
 
     def detect_domain_expired(self):
         result = []
-        test_name = "domain_expired"
+        test_name = "aws_route53_domain_expired"
 
         domains = self.route53_domains
 

--- a/src/auto-posture-evaluator/testers/route53_tester.py
+++ b/src/auto-posture-evaluator/testers/route53_tester.py
@@ -17,7 +17,7 @@ class Tester(interfaces.TesterInterface):
         self.user_id = boto3.client('sts').get_caller_identity().get('UserId')
         self.account_arn = boto3.client('sts').get_caller_identity().get('Arn')
         self.account_id = boto3.client('sts').get_caller_identity().get('Account')
-        self.route53_region = os.environ("AUTOPOSTURE_ROUTE53_DOMAINS_REGION") if os.environ.get("AUTOPOSTURE_ROUTE53_DOMAINS_REGION") else "us-east-1"
+        self.route53_region = os.environ["AUTOPOSTURE_ROUTE53_DOMAINS_REGION"] if os.environ.get("AUTOPOSTURE_ROUTE53_DOMAINS_REGION") else "us-east-1"
         self.aws_route53_domain_client = boto3.client('route53domains', region_name=self.route53_region)
         self.route53_domains = self._get_all_route53_domains()
 

--- a/src/auto-posture-evaluator/testers/route53_tester.py
+++ b/src/auto-posture-evaluator/testers/route53_tester.py
@@ -30,7 +30,8 @@ class Tester(interfaces.TesterInterface):
             return \
                 self.detect_dangling_dns_records() + \
                 self.route53_domain_expiry_in_7_days() + \
-                self.detect_domain_is_not_locked_for_transfer()
+                self.detect_domain_is_not_locked_for_transfer() + \
+                self.detect_domain_auto_renewal_disabled()
         else:
             raise Exception("No Route53 data could be retrieved.")
 
@@ -177,4 +178,38 @@ class Tester(interfaces.TesterInterface):
                     "test_result": "issue_found"
                 })
         
+        return result
+
+    def detect_domain_auto_renewal_disabled(self):
+        result = []
+        test_name = "domain_auto_renewal_disabled"
+
+        domains = self.route53_domains
+
+        for domain in domains:
+            domain_name = domain['DomainName']
+            auto_renew = domain['AutoRenew']
+
+            if auto_renew:
+                result.append({
+                    "user": self.user_id,
+                    "account_arn": self.account_arn,
+                    "account": self.account_id,
+                    "test_name": test_name,
+                    "item": domain_name,
+                    "item_type": "domain_name",
+                    "timestamp": time.time(),
+                    "test_result": "no_issue_found" 
+                })
+            else:
+                result.append({
+                    "user": self.user_id,
+                    "account_arn": self.account_arn,
+                    "account": self.account_id,
+                    "test_name": test_name,
+                    "item": domain_name,
+                    "item_type": "domain_name",
+                    "timestamp": time.time(),
+                    "test_result": "issue_found" 
+                })
         return result

--- a/src/auto-posture-evaluator/testers/route53_tester.py
+++ b/src/auto-posture-evaluator/testers/route53_tester.py
@@ -109,15 +109,10 @@ class Tester(interfaces.TesterInterface):
 
     def route53_domain_expiry_in_7_days(self):
         result = []
-        domains = []
         test_name = "route53_domain_expiry_in_7_days"
 
-        paginator = self.aws_route53_domain_client.get_paginator('list_domains')
-        response_iterator = paginator.paginate()
+        domains = self.route53_domains
 
-        for page in response_iterator:
-            domains.extend(page['Domains'])
-            
         for domain in domains:
             domain_name = domain['DomainName']
             expiry_date = domain['Expiry']
@@ -147,17 +142,13 @@ class Tester(interfaces.TesterInterface):
                     "timestamp": time.time(),
                     "test_result": "issue_found"
                 })
+        return result
 
     def detect_domain_is_not_locked_for_transfer(self):
         result = []
-        domains = []
         test_name = "domain_is_not_locked_for_transfer"
 
-        paginator = self.aws_route53_domain_client.get_paginator('list_domains')
-        response_iterator = paginator.paginate()
-
-        for page in response_iterator:
-            domains.extend(page['Domains'])
+        domains = self.route53_domains
         
         for domain in domains:
             domain_name = domain['DomainName']


### PR DESCRIPTION
Added the following test

- Route53 domain expiry in 7 days
- Domain transfer is locked
- Domain auto-renew is disabled
- Domain expired