### PR TITLE
Use private key only

### DIFF
--- a/src/auto-posture-evaluator/auto_posture_evaluator.py
+++ b/src/auto-posture-evaluator/auto_posture_evaluator.py
@@ -63,7 +63,7 @@ class AutoPostureEvaluator:
         self.private_key = os.environ.get('PRIVATE_KEY')
         self.context = SecurityReportContext(
             private_key=self.private_key,
-            application_name=os.environ.get('APPLICATION_NAME', 'NO_APP_NAME'),
+            application_name='test-autoposture',
             subsystem_name=os.environ.get('SUBSYSTEM_NAME', 'NO_SUB_NAME'),
             computer_name="CoralogixServerlessLambda")
         self.tests = []

--- a/src/auto-posture-evaluator/auto_posture_evaluator.py
+++ b/src/auto-posture-evaluator/auto_posture_evaluator.py
@@ -76,7 +76,7 @@ class AutoPostureEvaluator:
         for i in range(0, len(self.tests)):
             cur_test_start_timestamp = datetime.datetime.now()
             tester = self.tests[i]
-            print("Executing", tester)
+            print("Executing", testers_module_names[i])
             try:
                 cur_tester = tester()
                 tester_result = cur_tester.run_tests()

--- a/src/auto-posture-evaluator/auto_posture_evaluator.py
+++ b/src/auto-posture-evaluator/auto_posture_evaluator.py
@@ -60,7 +60,6 @@ class AutoPostureEvaluator:
         port = os.environ.get("CORALOGIX_ENDPOINT_PORT", "443")
         self.channel = Channel(host=endpoint, port=int(port), ssl=True)
         self.client = SecurityReportIngestionServiceStub(channel=self.channel)
-        self.api_key = os.environ.get('PRIVATE_KEY')
         self.private_key = os.environ.get('PRIVATE_KEY')
         self.context = SecurityReportContext(
             private_key=self.private_key,
@@ -130,7 +129,7 @@ class AutoPostureEvaluator:
                 testers_module_names[i]))
             try:
                 loop: AbstractEventLoop = asyncio.get_event_loop()
-                loop.run_until_complete(self.client.post_security_report(api_key=self.api_key, security_report=report))
+                loop.run_until_complete(self.client.post_security_report(api_key=self.private_key, security_report=report))
             except Exception as ex:
                 print("ERROR: Failed to send " + str(len(security_report_test_result_list)) + " for tester " +
                       str(testers_module_names[i]) + " events due to the following exception: " + str(ex))


### PR DESCRIPTION
This PR adds the following functionality:

 - Don't call xdr-ingestion endpoint if there are no results
 - Use secret-key for authorisation
 - Use predefined `application_name` 

  

  