### PR TITLE
Add a Resource Tags application

### DIFF
--- a/src/resource-tags/LICENSE
+++ b/src/resource-tags/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2022 Coralogix Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/resource-tags/README.md
+++ b/src/resource-tags/README.md
@@ -1,0 +1,15 @@
+# Coralogix Resource Tags
+
+This application collect AWS resource tags and sends them to your **Coralogix** account.
+
+It requires the following parameters:
+* **CoralogixRegion** - Possible values are `Europe`, `Europe2`, `US`, `Singapore` or `India`. Choose `Europe` if your Coralogix account URL ends with `.com`, `US` if it ends with `.us` and `India` if it ends with `.in`. This is a **Coralogix** parameter and does not relate to your to your AWS region.
+* **PrivateKey** - Can be found in your **Coralogix** account under `Settings` -> `Send your logs`. It is located in the upper left corner.
+
+Do not change the `FunctionMemorySize` and `FunctionTimeout` parameters.
+
+The application will only collect tags for the AWS region where it is installed.
+
+## License
+
+This project is licensed under the Apache-2.0 License.

--- a/src/resource-tags/index.js
+++ b/src/resource-tags/index.js
@@ -1,0 +1,89 @@
+/**
+ * AWS Resource Tags Lambda function for Coralogix
+ *
+ * @file        This file is lambda function source code
+ * @author      Coralogix Ltd. <info@coralogix.com>
+ * @link        https://coralogix.com/
+ * @copyright   Coralogix Ltd.
+ * @licence     Apache-2.0
+ * @version     1.0.0
+ * @since       1.0.0
+ */
+
+"use strict";
+
+// Import required libraries
+const aws = require("aws-sdk");
+const assert = require("assert");
+const resourcegroupstaggingapi = new aws.ResourceGroupsTaggingAPI();
+const protoLoader = require("@grpc/proto-loader");
+const grpc = require("@grpc/grpc-js");
+const parseArn = require("./resources").parseArn;
+
+// Check Lambda function parameters
+assert(process.env.private_key, "No private key!");
+assert(process.env.coralogix_metadata_url, "No Coralogix metadata URL key!");
+
+// Load .proto definition
+const metadataServiceDefinition = protoLoader.loadSync("service.proto");
+const metadataService = grpc.loadPackageDefinition(metadataServiceDefinition);
+
+function createCredentials(privateKey) {
+    return grpc.credentials.combineChannelCredentials(
+        grpc.credentials.createSsl(),
+        grpc.credentials.createFromMetadataGenerator(function (options, callback) {
+            const metadata = new grpc.Metadata();
+            metadata.set('authorization', 'Bearer ' + privateKey);
+            return callback(null, metadata);
+        })
+    );
+}
+
+const credentials = createCredentials(process.env.private_key);
+const metadataClient = new metadataService.com.coralogix.metadata.gateway.v1.MetadataGatewayService(
+    process.env.coralogix_metadata_url,
+    credentials
+);
+
+/**
+ * @description Lambda function handler
+ * @param {object} event - Event data
+ * @param {object} context - Function context
+ * @param {function} callback - Function callback
+ */
+function handler(event, context, callback) {
+    resourcegroupstaggingapi.getResources({
+        // The current API can only accept resources with globally unique IDs
+        ResourceTypeFilters: [
+            "ec2:instance",
+        ],
+    }).eachPage(function (err, data, done) {
+        if (err) return callback(err);
+        if (data) {
+            const resources = [];
+            data.ResourceTagMappingList.forEach(function (resourceTagMapping) {
+                const [resourceType, resourceId] = parseArn(resourceTagMapping.ResourceARN);
+                resources.push({
+                    resourceId,
+                    resourceType,
+                    tags: formatTags(resourceTagMapping.Tags)
+                });
+            });
+            console.info("Submitting " + resources.length + " resources");
+            metadataClient.submit({ resources }, function (err, result) {
+                if (err) return callback(err);
+                done();
+            });
+        } else {
+            return callback(null);
+        };
+    });
+}
+
+function formatTags(tagList) {
+    return tagList.map(function (tag) {
+        return ({ key: tag.Key, value: tag.Value });
+    });
+}
+
+exports.handler = handler;

--- a/src/resource-tags/package.json
+++ b/src/resource-tags/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "coralogix-resource-tags",
+  "title": "AWS Resource Tags Lambda function for Coralogix",
+  "version": "1.0.0",
+  "description": "AWS Lambda function to send AWS resource tags to Coralogix",
+  "homepage": "https://coralogix.com",
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "author": {
+    "name": "Coralogix",
+    "email": "info@coralogix.com",
+    "url": "https://coralogix.com"
+  },
+  "engines": {
+    "node": "16.x"
+  },
+  "contributors": [
+    {
+      "name": "Roman Timushev",
+      "email": "roman.timushev@coralogix.com",
+      "url": "https://github.com/rtimush"
+    }
+  ],
+  "keywords": [
+    "coralogix",
+    "logs",
+    "tags",
+    "aws",
+    "javascript",
+    "library"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coralogix/coralogix-aws-serverless.git"
+  },
+  "bugs": {
+    "email": "info@coralogix.com",
+    "url": "https://github.com/coralogix/coralogix-aws-serverless/issues"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "aws-sdk": "^2.654.0",
+    "jest": "^29.1.2"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.6.8",
+    "@grpc/proto-loader": "^0.7.0"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "service.proto",
+    "resources.js"
+  ]
+}

--- a/src/resource-tags/resources.js
+++ b/src/resource-tags/resources.js
@@ -1,0 +1,22 @@
+function parseArn(resourceArn) {
+    const arn = resourceArn.split(":");
+    const partition = arn[1];
+    const service = arn[2];
+    if (arn.length > 6) {
+        const resourceId = arn[6];
+        const resourceType = partition + ":" + service + ":" + arn[5];
+        return [resourceType, resourceId]
+    } else {
+        const resource = splitOnce(arn[5], "/");
+        const resourceId = resource[1];
+        const resourceType = partition + ":" + service + ":" + resource[0];
+        return [resourceType, resourceId]
+    }
+}
+
+function splitOnce(s, on) {
+    const parts = s.split(on)
+    return [parts[0], parts.length > 1 ? parts.slice(1).join(on) : null]
+}
+
+exports.parseArn = parseArn;

--- a/src/resource-tags/resources.test.js
+++ b/src/resource-tags/resources.test.js
@@ -1,0 +1,19 @@
+const parseArn = require('./resources').parseArn;
+
+describe('ARN parser', () => {
+    it('parses EC2 instance ARNs', () => {
+        const [resourceType, resourceId] = parseArn("arn:aws:ec2:eu-west-1:11111:instance/i-123");
+        expect(resourceType).toEqual("aws:ec2:instance");
+        expect(resourceId).toEqual("i-123");
+    });
+    it('parses application ALB ARNs', () => {
+        const [resourceType, resourceId] = parseArn("arn:aws:elasticloadbalancing:eu-west-1:11111:loadbalancer/app/foo/123");
+        expect(resourceType).toEqual("aws:elasticloadbalancing:loadbalancer");
+        expect(resourceId).toEqual("app/foo/123");
+    });
+    it('parses RDS DB ARNs', () => {
+        const [resourceType, resourceId] = parseArn("arn:aws:rds:eu-west-1:11111:db:foo");
+        expect(resourceType).toEqual("aws:rds:db");
+        expect(resourceId).toEqual("foo");
+    });
+});

--- a/src/resource-tags/service.proto
+++ b/src/resource-tags/service.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package com.coralogix.metadata.gateway.v1;
+
+message SubmitMetadataRequest { repeated ResourceMetadata resources = 1; }
+
+message ResourceMetadata {
+  string resourceId = 1;
+  string resourceType = 2;
+  repeated ResourceTag tags = 3;
+}
+
+message ResourceTag {
+  string key = 1;
+  string value = 2;
+}
+
+message SubmitMetadataResponse {}
+
+service MetadataGatewayService {
+  rpc Submit(SubmitMetadataRequest) returns (SubmitMetadataResponse) {}
+}

--- a/src/resource-tags/template.yaml
+++ b/src/resource-tags/template.yaml
@@ -1,0 +1,172 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Send resource tags to Coralogix.
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: Coralogix-Resource-Tags
+    Description: Send resource tags to Coralogix.
+    Author: Coralogix
+    SpdxLicenseId: Apache-2.0
+    LicenseUrl: LICENSE
+    ReadmeUrl: README.md
+    Labels:
+      - coralogix
+      - logs
+      - tags
+    HomePageUrl: https://coralogix.com
+    SemanticVersion: 1.0.0
+    SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Coralogix Configuration
+        Parameters:
+          - CoralogixRegion
+          - PrivateKey
+      - Label:
+          default: Tag Collection Configuration
+        Parameters:
+          - Schedule
+      - Label:
+          default: Lambda Configuration
+        Parameters:
+          - FunctionArchitecture
+          - FunctionMemorySize
+          - FunctionTimeout
+          - NotificationEmail
+    ParameterLabels:
+      CoralogixRegion:
+        default: Region
+      PrivateKey:
+        default: Private Key
+      Schedule:
+        default: Schedule
+      FunctionArchitecture:
+        default: Architecture
+      FunctionMemorySize:
+        default: Memory
+      FunctionTimeout:
+        default: Timeout
+      NotificationEmail:
+        default: Notification Email
+Parameters:
+  CoralogixRegion:
+    Type: String
+    Description: The Coralogix location region [Europe, Europe2, India, Singapore, US]
+    AllowedValues:
+      - DevShared
+      - Europe
+      - Europe2
+      - India
+      - Singapore
+      - US
+    Default: Europe
+  PrivateKey:
+    Type: String
+    Description: The Coralogix private key which is used to validate your authenticity
+    AllowedPattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+    ConstraintDescription: The PrivateKey should be valid UUID string
+    MinLength: 36
+    MaxLength: 36
+    NoEcho: true
+  Schedule:
+    Type: String
+    Description: Collect tags on a specific schedule
+    MaxLength: 256
+    Default: "rate(10 minutes)"
+  FunctionArchitecture:
+    Type: String
+    Description: Lambda function architecture [x86_64, arm64]
+    AllowedValues:
+      - x86_64
+      - arm64
+    Default: x86_64
+  FunctionMemorySize:
+    Type: Number
+    Description: Lambda function memory limit
+    MinValue: 128
+    MaxValue: 10240
+    Default: 1024
+  FunctionTimeout:
+    Type: Number
+    Description: Lambda function timeout limit
+    MinValue: 30
+    MaxValue: 900
+    Default: 300
+  NotificationEmail:
+    Type: String
+    Description: Failure notification email address
+    MaxLength: 320
+    Default: ""
+Mappings:
+  CoralogixRegionMap:
+    DevShared:
+      MetadataUrl: metadata-gateway.dev-shared.coralogix.net:443
+    Europe:
+      MetadataUrl: metadata-gateway.coralogix.com:443
+    Europe2:
+      MetadataUrl: metadata-gateway.eu2.coralogix.com:443
+    India:
+      MetadataUrl: metadata-gateway.app.coralogix.in:443
+    Singapore:
+      MetadataUrl: metadata-gateway.coralogixsg.com:443
+    US:
+      MetadataUrl: metadata-gateway.coralogix.us:443
+Conditions:
+  IsNotificationEnabled:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: NotificationEmail
+          - ""
+Resources:
+  LambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: Send resource tags to Coralogix.
+      CodeUri: .
+      Handler: index.handler
+      Runtime: nodejs16.x
+      Architectures:
+        - Ref: FunctionArchitecture
+      MemorySize:
+        Ref: FunctionMemorySize
+      Timeout:
+        Ref: FunctionTimeout
+      Environment:
+        Variables:
+          coralogix_metadata_url:
+            Fn::FindInMap:
+              - CoralogixRegionMap
+              - Ref: CoralogixRegion
+              - MetadataUrl
+          private_key:
+            Ref: PrivateKey
+      Events:
+        ScheduledEvent:
+          Type: Schedule
+          Properties:
+            Schedule:
+              Ref: Schedule
+            Enabled: True
+      EventInvokeConfig:
+        DestinationConfig:
+          OnFailure:
+            Type: SNS
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Sid: GetResourcesPolicy
+              Effect: Allow
+              Action:
+                - tag:GetResources
+              Resource: "*"
+
+  LambdaFunctionNotificationSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: IsNotificationEnabled
+    Properties:
+      Protocol: email
+      Endpoint:
+        Ref: NotificationEmail
+      TopicArn:
+        Ref: LambdaFunction.DestinationTopic


### PR DESCRIPTION
This is a new serverless application that allows to collect tags for the resources in a AWS account region.
The logs can then be enriched with the tags collected by this application.