### PR TITLE
Send JSON text with more cloudwatch data

### DIFF
--- a/src/cloudwatch-logs/index.js
+++ b/src/cloudwatch-logs/index.js
@@ -152,7 +152,7 @@ function handler(event, context, callback) {
                         "subsystemName": subName,
                         "timestamp": microtime.now(),
                         "severity": getSeverityLevel(logEvent.toLowerCase()),
-                        "text": logEvent,
+                        "text": JSON.stringify({"log": logEvent, "logGroup": resultParsed.logGroup, "logStream": resultParsed.logStream}),
                         "threadId": resultParsed.logStream
                     };
                 })


### PR DESCRIPTION
The lambda function currently sends only the logEvent text, which is a non-JSON text in many cases and with no metadata context like the log group and the log stream from which the event is coming.