### PR TITLE
Don't treat subdirectories of a package as packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get Changed Packages
         id: get-changed-packages
         run: |
-          export PACKAGES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha || 'origin/master' }} ${{ github.sha }} src/ | xargs -n1 dirname | xargs -n1 basename | sort | uniq | jq -rcnR '[inputs]')
+          export PACKAGES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha || 'origin/master' }} ${{ github.sha }} src/ | xargs -n1 dirname | -r 's/src\/([^\/]+).*$/src\/\1/g' | xargs -n1 basename | sort | uniq | jq -rcnR '[inputs]')
           echo "::set-output name=packages::$PACKAGES"
 
   validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get Changed Packages
         id: get-changed-packages
         run: |
-          export PACKAGES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha || 'origin/master' }} ${{ github.sha }} src/ | xargs -n1 dirname | -r 's/src\/([^\/]+).*$/src\/\1/g' | xargs -n1 basename | sort | uniq | jq -rcnR '[inputs]')
+          export PACKAGES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha || 'origin/master' }} ${{ github.sha }} src/ | xargs -n1 dirname | sed -r 's/src\/([^\/]+).*$/src\/\1/g' | xargs -n1 basename | sort | uniq | jq -rcnR '[inputs]')
           echo "::set-output name=packages::$PACKAGES"
 
   validate:


### PR DESCRIPTION
This fixes an issue I'm experiencing in #36 where actions try to verify `v1` and `proto` packages which don't exist (See: https://github.com/coralogix/coralogix-aws-serverless/actions/runs/4619243053/jobs/8167732239?pr=36 )

The problem is that changes are detected in 
```
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata/proto/opentelemetry/proto/common/v1
src/resource-metadata/proto
src/resource-metadata
```
which should lead to `resource-metadata` being recognized as a package that need verification, but it leads to `v1`and `proto` also being detected as such.

The `sed` I added will turn this list into
```
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
src/resource-metadata
```

