### PR TITLE
support for ap-east-1 region for serverless s3 bucket

### DIFF
--- a/infra/terragrunt.hcl
+++ b/infra/terragrunt.hcl
@@ -3,7 +3,7 @@ locals {
     "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "eu-north-1",
     "us-east-1", "us-east-2", "us-west-1", "us-west-2",
     "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
-    "ca-central-1", "eu-south-1"
+    "ca-central-1", "eu-south-1", "ap-east-1"
   ]
 }
 


### PR DESCRIPTION
added support for ap-east-1 for serverless s3 buckets so that clients using those regions can get benefit from it.

not sure if the bucket name "coralogix-serverless-repo-ap-east-1" would be available for use or if there is anything else that needs to be done from the coralogix side 