### PR TITLE
FIX MongoDB special character handling

### DIFF
--- a/src/mongodb-atlas/CHANGELOG.md
+++ b/src/mongodb-atlas/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## MongoDB-Atlas
+
+### v1.0.10 / 2023-06-21
+
+* [FIX] Add Special Character handling for Project names
+* [DOC] Added installation details in README.md

--- a/src/mongodb-atlas/README.md
+++ b/src/mongodb-atlas/README.md
@@ -1,6 +1,58 @@
 # Coralogix-MongoDB-Atlas
 
-Collects and pushes MongoDB Atlas cluster logs, metrics, events, alerts to Coralogix.
+Collects and pushes MongoDB Atlas cluster logs, metrics (as logs), events, and alerts to Coralogix.
+
+To deploy this integration you'll need the following:
+
+* **MongoDB Atlas** Project with a compatible Cluster
+    * Can't be M0 (Free), M2/M5 (Shared)
+    * Full details of Cluster type limitations: [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/#service-m0--free-cluster---m2--and-m5-limitations)
+* **MongoDB Atlas** Project API key with at minimum "Project Data Access Read Write" permissions. 
+    * Not a key from "Data API"
+* **Coralogix** Account and associated Region and Private Key
+
+## Installation
+This MongoDB Atlas integration can be deployed by clicking the link below and signing into your AWS account:
+[Deployment link](https://serverlessrepo.aws.amazon.com/applications/eu-central-1/597078901540/Coralogix-MongoDB-Atlas)
+
+In the Application Settings, fill in the appropriate values:
+
+## Fields
+
+* **Application name** - The stack name of this application created via AWS CloudFormation.
+
+* **NotificationEmail** - If the lambda's execute fails an auto email sends to this address to notify it via SNS (requires you have a working SNS, with a validated domain).
+
+* **ApplicationName** - The name of the Coralogix application you wish to assign to this lambda.
+
+* **CoralogixRegion** - The Coralogix location region, possible options are ``Europe``, ``Europe2``, ``India``, ``Singapore``, ``US``.
+
+* **Enabled** - MongoDB Atlas API pulling state
+
+* **FunctionArchitecture** - Lambda function architecture, possible options are ``x86_64``, ``arm64``.
+
+* **FunctionMemorySize** - Do not change! This is the maximum allocated memory that this lambda can consume, the default is ``1024``.
+
+* **FunctionTimeout** - Do not change! This is the maximum time in seconds the function may be allowed to run, the default is ``300``.
+
+* **MongoDBAtlasClusterName** - MongoDB Atlas Cluster Name
+
+* **MongoDBAtlasMetricsGranularity** - MongoDB Atlas Cluster Metrics granularity
+
+* **MongoDBAtlasPrivateKey** - MongoDB Atlas API Private Key. Needs to have Read/Write permissions to the Project listed below.
+
+* **MongoDBAtlasProjectName** - MongoDB Atlas Project Name.
+
+* **MongoDBAtlasPublicKey** - MongoDB Atlas API Public Key. Found under Project - Access Manager, API Keys. Needs to have Read/Write permissions to the Project listed above.
+
+* **MongoDBAtlasResources** - MongoDB Atlas Resources to collect.
+
+* **PrivateKey** - Your Coralogix secret key. Can be found in your **Coralogix** account under `Settings` -> `Send your logs`. It is located in the upper left corner.
+
+* **Schedule** - MongoDB Atlas API pulling schedule. In [AWS Cloudwatch "rate" format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions) Default: rate(5 minute)
+
+* **SubsystemName** - The subsystem name you wish to allocate to this log shipper.
+
 
 ## License
 

--- a/src/mongodb-atlas/index.js
+++ b/src/mongodb-atlas/index.js
@@ -6,7 +6,7 @@
  * @link        https://coralogix.com/
  * @copyright   Coralogix Ltd.
  * @licence     Apache-2.0
- * @version     1.0.10
+ * @version     1.0.11
  * @since       1.0.0
  */
 
@@ -34,6 +34,7 @@ coralogix.CoralogixCentralLogger.configure(new coralogix.LoggerConfig({
     privateKey: process.env.CORALOGIX_PRIVATE_KEY
 }));
 const logger = new coralogix.CoralogixCentralLogger();
+const encodedProjectName = encodeURIComponent(process.env.MONGODB_ATLAS_PROJECT_NAME);
 
 /**
  * @description Authorizes to MongoDB Atlas API
@@ -176,7 +177,7 @@ function handler(event, context, callback) {
         FunctionName: context.functionName
     }, (error, func) => {
         if (!error) {
-            mongoApi(`/api/atlas/v1.0/groups/byName/${process.env.MONGODB_ATLAS_PROJECT_NAME}`).then((project) => {
+            mongoApi(`/api/atlas/v1.0/groups/byName/${encodedProjectName}`).then((project) => {
                 process.env.MONGODB_ATLAS_RESOURCES.split(",").forEach((resource) => {
                     switch(resource) {
                         case "mongodb":

--- a/src/mongodb-atlas/package.json
+++ b/src/mongodb-atlas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-mongodb-atlas",
   "title": "AWS Lambda function for MongoDB Atlas and Coralogix integration",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "AWS Lambda function for collecting and sending MongoDB Atlas cluster logs, metrics, events, alerts to Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/mongodb-atlas/template.yaml
+++ b/src/mongodb-atlas/template.yaml
@@ -18,7 +18,7 @@ Metadata:
       - events
       - alerts
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
 Parameters:
   CoralogixRegion:


### PR DESCRIPTION
# Description

Updated MongoDB Atlas integration to handle special characters in Project Name.

# How Has This Been Tested?

Testing was performed with an M10 MongoDB Atlas instance and deployment in AWS. Logs and Metrics (as logs) were transmitted successfully for project name with special characters `Project( ) @ & + : . _ - ' ,`

Deployment via SAR and altered function code with fix. Reviewed Cloudwatch logs for errors and observed Coralogix platform for ingest.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)