### PR TITLE
Bugfix/ecr more than 100 results per image

### DIFF
--- a/src/ecr/CHANGELOG.md
+++ b/src/ecr/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## ecr
+
+## 1.0.4 / 9/8/2023
+
+* [Update] Add summary log to be sent with every scan with all relevant scan metadata.
+* [Bugfix] Added support for more than 100 result per image.
+
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->

--- a/src/ecr/index.js
+++ b/src/ecr/index.js
@@ -56,6 +56,9 @@ function handler(event, context, callback) {
         callback(err);;
       } else {
         const findings = data['imageScanFindings']['findings'];
+        let summary_log = {"ecr_scan_summery": event['detail']};
+        sendLogs(summary_log);
+
         for (let i = 0; i < findings.length; i++) {
             const log = {
                 "metadata": {

--- a/src/ecr/index.js
+++ b/src/ecr/index.js
@@ -6,7 +6,7 @@
  * @link        https://coralogix.com/
  * @copyright   Coralogix Ltd.
  * @licence     Apache-2.0
- * @version     1.0.3
+ * @version     1.0.4
  * @since       1.0.0
  */
 
@@ -49,8 +49,9 @@ function sendLogs(content) {
 function handler(event, context, callback) {
     const repositoryName = event['detail']['repository-name'];
     const imageId = { imageDigest: event['detail']['image-digest'] };
+    const maxResults = 1000;
 
-    ecr.describeImageScanFindings({ repositoryName, imageId }, (err, data) => {
+    ecr.describeImageScanFindings({ repositoryName, imageId, maxResults }, (err, data) => {
       if (err) {
         callback(err);;
       } else {

--- a/src/ecr/index.js
+++ b/src/ecr/index.js
@@ -53,7 +53,7 @@ function handler(event, context, callback) {
 
     ecr.describeImageScanFindings({ repositoryName, imageId, maxResults }, (err, data) => {
       if (err) {
-        callback(err);;
+        callback(err);
       } else {
         const findings = data['imageScanFindings']['findings'];
         let summary_log = {"ecr_scan_summary": event['detail']};

--- a/src/ecr/index.js
+++ b/src/ecr/index.js
@@ -56,7 +56,7 @@ function handler(event, context, callback) {
         callback(err);;
       } else {
         const findings = data['imageScanFindings']['findings'];
-        let summary_log = {"ecr_scan_summery": event['detail']};
+        let summary_log = {"ecr_scan_summary": event['detail']};
         sendLogs(summary_log);
 
         for (let i = 0; i < findings.length; i++) {

--- a/src/ecr/package.json
+++ b/src/ecr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-ecr-image-scan-findings",
   "title": "AWS ECR Findings to Coralogix",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "AWS Lambda function to send ECR image scan findings to Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/ecr/template.yaml
+++ b/src/ecr/template.yaml
@@ -17,7 +17,7 @@ Metadata:
       - image
       - vulnerabilities
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.0.3
+    SemanticVersion: 1.0.4
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description
BUGFIX - Added support to more than the default 100 results.
FEATURE - Added a summary log with all the generic metadata of the complete scan

Tested the results with 3 scanned images

# Checklist:
- [ V] I have updated the versions in the changed module in the template index.js and package.json files.
- [ V] I have updated the relevant component changelog(s)
- [V ] This change does not affect module (e.g. it's readme file change)