### PR TITLE
Stop resource-metadata from failing on issue with single lambda function

### DIFF
--- a/src/resource-metadata/CHANGELOG.md
+++ b/src/resource-metadata/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata
 
+### 1.2.6 / 13.12.2023
+* [Change] The function will not fail when it can't collect metadata of some lambda function
+
 ### 1.2.5 / 7.12.2023
 * [Update] Add filtering of Lambda functions.
 

--- a/src/resource-metadata/common.js
+++ b/src/resource-metadata/common.js
@@ -33,3 +33,14 @@ export const traverse = async (array, f) => {
     }
     return results;
 }
+
+export const flatTraverse = async (array, f) => {
+    const results = [];
+    for (var i = 0; i < array.length; i++) {
+        let result = await f(array[i], i)
+        if (result) {
+            results.push(result);
+        }
+    }
+    return results;
+}

--- a/src/resource-metadata/package.json
+++ b/src/resource-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-tags",
   "title": "AWS Resource Tags Lambda function for Coralogix",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "AWS Lambda function to send AWS resource tags to Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata/template.yaml
+++ b/src/resource-metadata/template.yaml
@@ -13,7 +13,7 @@ Metadata:
       - coralogix
       - metadata
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.2.5
+    SemanticVersion: 1.2.6
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description

This pr makes `resource-metadata` report issues as WARN logs instead of failing. This means that the metadata of other functions will be successfully delivered even if there are some function for which the metadata couldn't be collected. Importantly we will still fail if the issue is global (affects all functions).

Fixes https://github.com/coralogix/terraform-coralogix-aws/issues/113

# How Has This Been Tested?

Adjusted role permissions to cause some failures and observed the behaviour of `resource-metadata`

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)