### PR TITLE
Correct conversion of tags to attributes

### DIFF
--- a/src/resource-metadata/CHANGELOG.md
+++ b/src/resource-metadata/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata
 
+### 1.2.7 / 13.12.2023
+* [Fix] Correct conversion of tags to attributes
+
 ### 1.2.6 / 13.12.2023
 * [Change] The function will not fail when it can't collect metadata of some lambda function
 

--- a/src/resource-metadata/ec2.js
+++ b/src/resource-metadata/ec2.js
@@ -57,11 +57,7 @@ const makeEc2InstanceResource = (i, region, accountId) => {
         stringAttr("host.name", name)
     }
 
-    if (i.Tags) {
-        Object.keys(i.Tags).forEach(key => {
-            attributes.push(stringAttr(`cloud.tag.${key}`, i.Tags[key]))
-        })
-    }
+    attributes.push(...convertEc2TagsToAttributes(i.Tags))
 
     return {
         resourceId: arn,
@@ -73,4 +69,12 @@ const makeEc2InstanceResource = (i, region, accountId) => {
             nanos: 0,
         },
     }
+}
+
+// WARNING the tags data structure is different in lambda and in ec2
+const convertEc2TagsToAttributes = tags => {
+    if (!tags) {
+        return []
+    }
+    return tags.map(tag => stringAttr(`cloud.tag.${tag.Key}`, tag.Value));
 }

--- a/src/resource-metadata/lambda.js
+++ b/src/resource-metadata/lambda.js
@@ -149,11 +149,7 @@ const makeLambdaFunctionResource = (f) => {
         stringAttr("lambda.last_update_status", f.Configuration.LastUpdateStatus),
     ]
 
-    if (f.Tags) {
-        Object.keys(f.Tags).forEach(key => {
-            attributes.push(stringAttr(`cloud.tag.${key}`, f.Tags[key]))
-        })
-    }
+    attributes.push(...convertFunctionTagsToAttributes(f.Tags))
 
     const reservedConcurrency = f.Concurrency?.ReservedConcurrentExecutions
     if (reservedConcurrency) {
@@ -170,6 +166,14 @@ const makeLambdaFunctionResource = (f) => {
             nanos: 0,
         },
     }
+}
+
+// WARNING the tags data structure is different in lambda and in ec2
+const convertFunctionTagsToAttributes = tags => {
+    if (!tags) {
+        return []
+    }
+    return Object.entries(tags).map(([key, value]) => stringAttr(`cloud.tag.${key}`, value));
 }
 
 const makeLambdaFunctionVersionResource = (fv, eventSourceMappings, maybePolicy) => {

--- a/src/resource-metadata/package.json
+++ b/src/resource-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-tags",
   "title": "AWS Resource Tags Lambda function for Coralogix",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "AWS Lambda function to send AWS resource tags to Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata/template.yaml
+++ b/src/resource-metadata/template.yaml
@@ -13,7 +13,7 @@ Metadata:
       - coralogix
       - metadata
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.2.6
+    SemanticVersion: 1.2.7
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description

Corrects conversion of EC2 tags to resource attributes.

# How Has This Been Tested?

Run with a test team in test env and verified EC2 and lambda resources sent.

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)