### PR TITLE
Update github actions to use node.js 20 [CDS-1221]

### DIFF
--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.8
+        uses: joerick/pr-labels-action@v1.0.9
         
   check-changelog-updates:
     if: "${{ needs.get-label.outputs.labels != ' skip-changelog ' }}"
@@ -23,7 +23,7 @@ jobs:
     needs: get-label
     name: Check changelog update
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Get changed files

--- a/.github/workflows/Synchronizing.yml
+++ b/.github/workflows/Synchronizing.yml
@@ -16,7 +16,7 @@ jobs:
       packages: ${{ env.packages }}
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Read matrix YAML
       id: read-matrix
       run: |
@@ -30,7 +30,7 @@ jobs:
         touch template-readme-directory/file.tmp
 
     - name: Upload template-readme-directory
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: template-readme-directory
         path: ./template-readme-directory/
@@ -39,7 +39,7 @@ jobs:
       run: touch change_file_list.txt
 
     - name: Upload changes file list
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: change_file_list
         path: change_file_list.txt
@@ -53,9 +53,9 @@ jobs:
         package: ${{ fromJSON(needs.Get-matrix.outputs.packages) }}
       max-parallel: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         with:
           filters: |
             '${{ matrix.package }}':
@@ -89,14 +89,14 @@ jobs:
       
       - if: steps.changes.outputs[matrix.package] == 'true' 
         name: Upload template-readme-directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: template-readme-directory
           path: ./template-readme-directory/ 
 
       - if: steps.changes.outputs[matrix.package] == 'true'      
         name: Download change_file_list
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: change_file_list
 
@@ -106,7 +106,7 @@ jobs:
           
       - if: steps.changes.outputs[matrix.package] == 'true' 
         name: Upload change_file_list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: change_file_list
           path: change_file_list.txt   
@@ -117,7 +117,7 @@ jobs:
     steps:
 
       - name: Checkout destination repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: coralogix/cloudformation-coralogix-aws
           token: ${{ secrets.GH_TOKEN }}
@@ -126,13 +126,13 @@ jobs:
         run: mkdir ./template-readme-directory
 
       - name: Download template-readme-directory
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: template-readme-directory
           path: ./template-readme-directory
 
       - name: Download change_file_list
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: change_file_list
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       packages: ${{ steps.get-changed-packages.outputs.packages }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -39,14 +39,14 @@ jobs:
         package: ${{ fromJSON(needs.check.outputs.packages) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
 
       - if: ${{ matrix.package != 'helper' }}
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -68,14 +68,14 @@ jobs:
         package: ${{ fromJSON(needs.check.outputs.packages) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
 
       - if: ${{ matrix.package != 'helper' }}
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -127,7 +127,7 @@ jobs:
           name: ${{ matrix.package }}-packaged.yaml
 
       - if: ${{ matrix.package != 'helper' }}
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Init
         working-directory: infra/
@@ -42,7 +42,7 @@ jobs:
       packages: ${{ steps.get-changed-packages.outputs.packages }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -63,7 +63,7 @@ jobs:
         package: ${{ fromJSON(needs.check.outputs.packages) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate
         working-directory: src/${{ matrix.package }}
@@ -79,7 +79,7 @@ jobs:
         package: ${{ fromJSON(needs.check.outputs.packages) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         working-directory: ./src/${{ matrix.package }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Store
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.package }}-packaged.yaml
           path: src/${{ matrix.package }}/packaged.yaml
@@ -113,7 +113,7 @@ jobs:
         package: ${{ fromJSON(needs.check.outputs.packages) }}
     steps:
       - name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.package }}-packaged.yaml
 


### PR DESCRIPTION
# Description
Update the github actions to use node.js 20 instead for node.js 16 to avoid the deprecated warnings
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the versions in the changed module in the template index.js and package.json files.
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect module (e.g. it's readme file change)