### PR TITLE
Create a new variable LogGroupPermissionPreFix and update the python code [CDS-1331]

### DIFF
--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## lambda-manager
 
+## 2.0.3  / 26-06-2024
+### 💡 Enhancements 💡
+- Add a new parameter LogGroupPermissionPreFix, when defined the lambda will not create permission for each log group, but 1 permission for the prefix defined in the parameter.
+
 ## 2.0.2  / 24-06-2024
 ### 💡 Enhancements 💡
 - Update the lambda to trigger on creation if ScanOldLogGroups is set to true

--- a/src/lambda-manager/README.md
+++ b/src/lambda-manager/README.md
@@ -8,12 +8,13 @@ Environment variables:
 |---|---|---|---|
 | RegexPattern | Set up this regex to match the Log Groups names that you want to automatically subscribe to the destination| | :heavy_check_mark: |
 | LogsFilter | Subscription filter to select which logs needs to be sent to Coralogix. For Example for Lambda Errors that are not sendable by Coralogix Lambda Layer '?REPORT ?"Task timed out" ?"Process exited before completing" ?errorMessage ?"module initialization error:" ?"Unable to import module" ?"ERROR Invoke Error" ?"EPSAGON_TRACE:"'. | | :heavy_check_mark: |
-| DESTINATION_ARN | Arn for the firehose to subscribe the log groups (By default is the firehose created by Serverless Template) | | :heavy_check_mark: |
-| DESTINATION_ROLE | Arn for the role to allow destination subscription to be pushed (Lambda or Firehose) | | :heavy_check_mark: |
+| DESTINATION_ARN | Arn for the firehose / lambda to subscribe the log groups | | :heavy_check_mark: |
+| DESTINATION_ROLE | Arn for the role to allow destination subscription to be pushed (needed only for Firehose) | | :heavy_check_mark: |
 | DESTINATION_TYPE | Type of destination (Lambda or Firehose) | | :heavy_check_mark: |
-| SCAN_OLD_LOGGROUPS | This will scan all LogGroups in the account and apply the subscription configured, will only run Once and set to false. Default is false | false | :heavy_check_mark: |
-| FunctionMemorySize | The maximum allocated memory this lambda may consume. Default value is the minimum recommended setting please consult coralogix support before changing. | 1024 |  |
-| FunctionTimeout | The maximum time in seconds the function may be allowed to run. Default value is the minimum recommended setting please consult coralogix support before changing. | 300 |  |
+| SCAN_OLD_LOGGROUPS | When set to true the lambda will scan all existing log group and add the ones that match the RegexPattern as a trigger, the scan will only happen on the creation of the lambda after that it will only detect a new log group. | false | |
+| LogGroupPermissionPreFix | Instead of creating one permission for each log group in the destination lambda, the code will take the prefix that you set in the parameter and create 1 permission for all of the log groups that match the prefix, for example if you will define "/aws/log/logs" than the lambda will create only 1 permission for all of your log groups that start with /aws/log/logs instead of 1 permision for each of the log group. use this parameter when you have more than 50 log groups. Pay attention that you will not see the log groups as a trigger in the lambda if you use this parameter. | n/a | |
+| FunctionMemorySize | The maximum allocated memory this lambda may consume. The default value is the minimum recommended setting please consult coralogix support before changing. | 1024 |  |
+| FunctionTimeout | The maximum time in seconds the function may be allowed to run. The default value is the minimum recommended setting please consult coralogix support before changing. | 300 |  |
 | NotificationEmail | Failure notification email address | | |
 
 ## Requirements

--- a/src/lambda-manager/lambda_function.py
+++ b/src/lambda-manager/lambda_function.py
@@ -4,141 +4,31 @@ import re
 import uuid
 import cfnresponse 
 
-def identify_arn_service(arn):
-    arn_parts = arn.split(':')
-    if len(arn_parts) < 6:
-        return "Invalid ARN format"
-    service = arn_parts[2]
-    if service == "lambda":
-        return "lambda"
-    elif service == "firehose":
-        return "firehose"
-    else:
-        return "Unknown AWS Service"
-
-def list_log_groups_and_subscriptions(cloudwatch_logs, regex_pattern, logs_filter, destination_arn, role_arn, filter_name, context):
-    log_groups = []
-    response = {'nextToken': None}  # Initialize with a dict containing nextToken as None
-    print("Scanning all log groups")
-    while response.get('nextToken') is not None or 'logGroups' not in response:
-        kwargs = {}
-        if 'nextToken' in response and response['nextToken'] is not None:
-            kwargs['nextToken'] = response['nextToken']
-        response = cloudwatch_logs.describe_log_groups(**kwargs)
-        log_groups.extend(response['logGroups'])
-    for log_group in log_groups:
-        log_group_name = log_group['logGroupName']
-        if regex_pattern and re.match(regex_pattern, log_group_name):
-            print(f"Log Group: {log_group_name}")
-
-            subscriptions = cloudwatch_logs.describe_subscription_filters(logGroupName=log_group_name)
-            subscriptions = subscriptions.get('subscriptionFilters')
-            print(f" Subscriptions: {subscriptions} for {log_group_name}")
-            print(f" Subscriptions length: {len(subscriptions)} for {log_group_name}")
-            if subscriptions is None or len(subscriptions) == 0:
-                print(f"  No subscriptions found for {log_group_name}")
-                destination_type = identify_arn_service(destination_arn)
-                print(f"  Subscribing {log_group_name} to {destination_type} {destination_arn}")
-                if destination_type == 'firehose':
-                    try:
-                        cloudwatch_logs.put_subscription_filter(
-                            destinationArn=destination_arn,
-                            roleArn=role_arn,
-                            filterName= filter_name,
-                            filterPattern=logs_filter,
-                            logGroupName=log_group_name,
-                        )
-                    except Exception as e:
-                        print(f"Failed to put subscription filter for {log_group_name}: {e}")
-                        continue
-                elif destination_type == 'lambda':
-                    try:
-                        lambda_client = boto3.client('lambda')
-                        region = context.invoked_function_arn.split(":")[3]
-                        account_id = context.invoked_function_arn.split(":")[4]
-                        lambda_client.add_permission(
-                          FunctionName=destination_arn,
-                          StatementId=f'allow-trigger-from-{log_group_name}',
-                          Action='lambda:InvokeFunction',
-                          Principal='logs.amazonaws.com',
-                          SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{log_group_name}:*',
-                        )
-                        cloudwatch_logs.put_subscription_filter(
-                            destinationArn=destination_arn,
-                            filterName= "coralogix-aws-shipper-cloudwatch-trigger",
-                            filterPattern=logs_filter,
-                            logGroupName=log_group_name,
-                        )
-                    except Exception as e:
-                        print(f"Failed to put subscription filter for {log_group_name}: {e}")
-                        continue
-                else:
-                    print(f"Invalid destination type {destination_type}")
-            for subscription in subscriptions:
-                print(f" subscription length {len(subscriptions)}")
-                print(f" subscription arn {subscription['destinationArn']}")
-                if subscription['destinationArn'] == destination_arn:
-                    print(f"  Subscription already exists for {log_group_name}")
-                    continue
-                if len(subscriptions) == 2:
-                    print(f"  Subscriptions limit for {log_group_name}")
-                    print(f" subscription length {len(subscriptions)}")
-                    continue
-
-                destination_type = identify_arn_service(destination_arn)
-                print(f"  Subscribing {log_group_name} to {destination_type} {destination_arn}")
-                if destination_type == 'firehose':
-                    try:
-                        cloudwatch_logs.put_subscription_filter(
-                            destinationArn=destination_arn,
-                            roleArn=role_arn,
-                            filterName= filter_name,
-                            filterPattern=logs_filter,
-                            logGroupName=log_group_name,
-                        )
-                    except Exception as e:
-                        print(f"Failed to put subscription filter for {log_group_name}: {e}")
-                        continue
-                elif destination_type == 'lambda':
-                    try:
-                        lambda_client = boto3.client('lambda')
-                        region = context.invoked_function_arn.split(":")[3]
-                        account_id = context.invoked_function_arn.split(":")[4]
-                        lambda_client.add_permission(
-                          FunctionName=destination_arn,
-                          StatementId=f'allow-trigger-from-{log_group_name}',
-                          Action='lambda:InvokeFunction',
-                          Principal='logs.amazonaws.com',
-                          SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{log_group_name}:*',
-                        )
-                        cloudwatch_logs.put_subscription_filter(
-                            destinationArn=destination_arn,
-                            filterName= "coralogix-aws-shipper-cloudwatch-trigger",
-                            filterPattern=logs_filter,
-                            logGroupName=log_group_name,
-                        )
-                    except Exception as e:
-                        print(f"Failed to put subscription filter for {log_group_name}: {e}")
-                        continue
-                else:
-                    print(f"Invalid destination type {destination_type}")
+cloudwatch_logs = boto3.client('logs')
 
 def lambda_handler(event, context):
     status = cfnresponse.SUCCESS
+    lambda_client = boto3.client('lambda')
     try:
-        cloudwatch_logs     = boto3.client('logs')
-        regex_pattern       = os.environ.get('REGEX_PATTERN')
+        regex_pattern_list  = os.environ.get('REGEX_PATTERN').split(',')
         destination_type    = os.environ.get('DESTINATION_TYPE')
         logs_filter         = os.environ.get('LOGS_FILTER', '')
         scan_all_log_groups = os.environ.get('SCAN_OLD_LOGGROUPS', 'false')
         destination_arn     = os.environ.get('DESTINATION_ARN')
         role_arn            = os.environ.get('DESTINATION_ROLE')
         filter_name         = 'Coralogix_Filter_' + str(uuid.uuid4())
+        log_group_permission_prefix = os.environ.get('LOG_GROUP_PERMISSION_PREFIX', '').split(',')
+        region              = context.invoked_function_arn.split(":")[3]
+        account_id          = context.invoked_function_arn.split(":")[4]
+
+        if "RequestType" in event and event['RequestType'] == 'Create' and log_group_permission_prefix != ['']:
+            print("Addning permissions in creation")
+            add_permissions_first_time(destination_arn, log_group_permission_prefix, region, account_id)
 
         print(f"Scanning all log groups: {scan_all_log_groups}")
         if scan_all_log_groups == 'true' and "RequestType" in event:
-            list_log_groups_and_subscriptions(cloudwatch_logs, regex_pattern, logs_filter, destination_arn, role_arn, filter_name, context)
-            lambda_client = boto3.client('lambda')
+            list_log_groups_and_subscriptions(cloudwatch_logs, regex_pattern_list, logs_filter, destination_arn, role_arn, filter_name, context,log_group_permission_prefix)
+
             function_name = context.function_name
 
             # Fetch the current function configuration
@@ -161,45 +51,23 @@ def lambda_handler(event, context):
         elif scan_all_log_groups != 'true' and "RequestType" not in event:
             log_group_to_subscribe = event['detail']['requestParameters']['logGroupName']
             print(f"Log Group: {log_group_to_subscribe}")
-            if regex_pattern and re.match(regex_pattern, log_group_to_subscribe):
-                if destination_type == 'firehose':
+            for regex_pattern in regex_pattern_list:
+                if regex_pattern and re.match(regex_pattern, log_group_to_subscribe):
+                    if destination_type == 'firehose':
+                        status = add_subscription(filter_name, logs_filter, log_group_to_subscribe, destination_arn, role_arn)
+                    elif destination_type == 'lambda':
                         try:
-                            cloudwatch_logs.put_subscription_filter(
-                                destinationArn=destination_arn,
-                                roleArn=role_arn,
-                                filterName= filter_name,
-                                filterPattern=logs_filter,
-                                logGroupName=log_group_to_subscribe,
-                            )
+                            if not check_if_log_group_exist_in_log_group_permission_prefix(log_group_to_subscribe, log_group_permission_prefix):
+                                add_permission_to_lambda(destination_arn, log_group_to_subscribe, region, account_id)
+                            status = add_subscription(filter_name, logs_filter, log_group_to_subscribe, destination_arn)
                         except Exception as e:
                             print(f"Failed to put subscription filter for {log_group_to_subscribe}: {e}")
                             status = cfnresponse.FAILED
-                elif destination_type == 'lambda':
-                    try:
-                        lambda_client = boto3.client('lambda')
-                        region = context.invoked_function_arn.split(":")[3]
-                        account_id = context.invoked_function_arn.split(":")[4]
-                        lambda_client.add_permission(
-                          FunctionName=destination_arn,
-                          StatementId=f'allow-trigger-from-{log_group_to_subscribe}',
-                          Action='lambda:InvokeFunction',
-                          Principal='logs.amazonaws.com',
-                          SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{log_group_to_subscribe}:*',
-                        )
-                        cloudwatch_logs.put_subscription_filter(
-                            destinationArn=destination_arn,
-                            filterName= "coralogix-aws-shipper-cloudwatch-trigger",
-                            filterPattern=logs_filter,
-                            logGroupName=log_group_to_subscribe,
-                        )
-                    except Exception as e:
-                        print(f"Failed to put subscription filter for {log_group_to_subscribe}: {e}")
+                    else:
+                        print(f"Invalid destination type {destination_type}")
                         status = cfnresponse.FAILED
                 else:
-                    print(f"Invalid destination type {destination_type}")
-                    status = cfnresponse.FAILED
-            else:
-                print(f"Loggroup {log_group_to_subscribe} excluded")
+                    print(f"Loggroup {log_group_to_subscribe} excluded")
     except Exception as e:
         print(f"Failed with exception: {e}")
         status = cfnresponse.FAILED
@@ -213,3 +81,121 @@ def lambda_handler(event, context):
                 {},
                 event.get('PhysicalResourceId', context.aws_request_id)
             )
+
+def list_log_groups_and_subscriptions(cloudwatch_logs, regex_pattern_list, logs_filter, destination_arn, role_arn, filter_name, context,log_group_permission_prefix):
+    '''Scan for all of the log groups in the region and add subscription to the log groups that match the regex pattern, this function will only run 1 time'''
+    log_groups = []
+    create_subscription = False
+    response = {'nextToken': None}  # Initialize with a dict containing nextToken as None
+    print("Scanning all log groups")
+    while response.get('nextToken') is not None or 'logGroups' not in response:
+        kwargs = {}
+        if 'nextToken' in response and response['nextToken'] is not None:
+            kwargs['nextToken'] = response['nextToken']
+        response = cloudwatch_logs.describe_log_groups(**kwargs)
+        log_groups.extend(response['logGroups'])
+    region = context.invoked_function_arn.split(":")[3]
+    account_id = context.invoked_function_arn.split(":")[4]
+    for log_group in log_groups:
+        log_group_name = log_group['logGroupName']
+        
+        subscriptions = cloudwatch_logs.describe_subscription_filters(logGroupName=log_group_name)
+        subscriptions = subscriptions.get('subscriptionFilters')
+
+        if subscriptions == None:
+            create_subscription = True
+        elif len(subscriptions) < 2:
+            create_subscription = True
+            for subscription in subscriptions:
+                print(f" subscription length {len(subscriptions)}")
+                print(f" subscription arn {subscription['destinationArn']}")
+                if subscription['destinationArn'] == destination_arn:
+                    print(f"  Subscription already exists for {log_group_name}")
+                    create_subscription = False
+                    break
+
+        if create_subscription:
+            for regex_pattern in regex_pattern_list:
+                if regex_pattern and re.match(regex_pattern, log_group_name):
+                    print(f"Log Group: {log_group_name}")
+                    if identify_arn_service(destination_arn) == "lambda":
+                        if not check_if_log_group_exist_in_log_group_permission_prefix(log_group_name, log_group_permission_prefix):
+                            add_permission_to_lambda(destination_arn, log_group_name, region, account_id)
+                        add_subscription(filter_name, logs_filter, log_group_name, destination_arn)
+                    else:
+                        add_subscription(filter_name, logs_filter, log_group_name, destination_arn, role_arn)
+                    break # no need to continue the loop if we find a match for the log group
+
+def add_subscription(filter_name: str, logs_filter: str, log_group_to_subscribe: str, destination_arn: str, role_arn: str = None) -> str:
+    '''Add subscription to CloudWatch log group'''
+    print(f"Adding subscription filter for {log_group_to_subscribe}")
+    try:
+        if role_arn is None:
+            cloudwatch_logs.put_subscription_filter(
+                destinationArn=destination_arn,
+                filterName= filter_name,
+                filterPattern=logs_filter,
+                logGroupName=log_group_to_subscribe,
+            )
+        else:
+            cloudwatch_logs.put_subscription_filter(
+                destinationArn=destination_arn,
+                roleArn=role_arn,
+                filterName= filter_name,
+                filterPattern=logs_filter,
+                logGroupName=log_group_to_subscribe,
+            )
+        return cfnresponse.SUCCESS
+    except Exception as e:
+        print(f"Failed to put subscription filter for {log_group_to_subscribe}: {e}")
+        return cfnresponse.FAILED
+
+def add_permissions_first_time(destination_arn: str, log_group_permission_prefix: list[str], region: str, account_id: str):
+    '''Add permissions to the lambda on the creation of the lambda function for the first time'''
+    lambda_client   = boto3.client('lambda')
+    for prefix in log_group_permission_prefix:
+        try:
+            lambda_client.add_permission(
+                FunctionName=destination_arn,
+                StatementId=f'allow-trigger-from-{prefix.replace("/","")}-log-groups',
+                Action='lambda:InvokeFunction',
+                Principal='logs.amazonaws.com',
+                SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{prefix}*:*',
+            )
+        except Exception as e:
+            print(f"Failed to add permission {prefix}: {e}")
+
+def add_permission_to_lambda(destination_arn: str, log_group_name: str, region: str, account_id: str):
+    '''In case that the log group is not part of the log_group_permission_prefix then add permissions for it to the lambda function'''
+    lambda_client   = boto3.client('lambda')
+    try:
+        lambda_client.add_permission(
+            FunctionName=destination_arn,
+            StatementId=f'allow-trigger-from-{log_group_name.replace('/','')}',
+            Action='lambda:InvokeFunction',
+            Principal='logs.amazonaws.com',
+            SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{log_group_name}:*',
+        )
+    except Exception as e:
+        print(f"Failed to add permission to lambda {destination_arn}: {e}")
+
+def check_if_log_group_exist_in_log_group_permission_prefix(log_group_name: str, log_group_permission_prefix: str) -> bool:
+    '''Check if the log group is part of the log_group_permission_prefix'''
+    if log_group_permission_prefix == ['']:
+        return False
+    for prefix in log_group_permission_prefix:
+        if log_group_name.startswith(prefix):
+            return True
+    return False
+
+def identify_arn_service(arn: str) -> str:
+    arn_parts = arn.split(':')
+    if len(arn_parts) < 6:
+        return "Invalid ARN format"
+    service = arn_parts[2]
+    if service == "lambda":
+        return "lambda"
+    elif service == "firehose":
+        return "firehose"
+    else:
+        return "Unknown AWS Service"

--- a/src/lambda-manager/lambda_function.py
+++ b/src/lambda-manager/lambda_function.py
@@ -54,11 +54,13 @@ def lambda_handler(event, context):
             for regex_pattern in regex_pattern_list:
                 if regex_pattern and re.match(regex_pattern, log_group_to_subscribe):
                     if destination_type == 'firehose':
+                        print(f"Adding subscription filter for {log_group_to_subscribe}")
                         status = add_subscription(filter_name, logs_filter, log_group_to_subscribe, destination_arn, role_arn)
                     elif destination_type == 'lambda':
                         try:
                             if not check_if_log_group_exist_in_log_group_permission_prefix(log_group_to_subscribe, log_group_permission_prefix):
                                 add_permission_to_lambda(destination_arn, log_group_to_subscribe, region, account_id)
+                            print(f"Adding subscription filter for {log_group_to_subscribe}")
                             status = add_subscription(filter_name, logs_filter, log_group_to_subscribe, destination_arn)
                         except Exception as e:
                             print(f"Failed to put subscription filter for {log_group_to_subscribe}: {e}")
@@ -107,8 +109,6 @@ def list_log_groups_and_subscriptions(cloudwatch_logs, regex_pattern_list, logs_
         elif len(subscriptions) < 2:
             create_subscription = True
             for subscription in subscriptions:
-                print(f" subscription length {len(subscriptions)}")
-                print(f" subscription arn {subscription['destinationArn']}")
                 if subscription['destinationArn'] == destination_arn:
                     print(f"  Subscription already exists for {log_group_name}")
                     create_subscription = False
@@ -121,14 +121,15 @@ def list_log_groups_and_subscriptions(cloudwatch_logs, regex_pattern_list, logs_
                     if identify_arn_service(destination_arn) == "lambda":
                         if not check_if_log_group_exist_in_log_group_permission_prefix(log_group_name, log_group_permission_prefix):
                             add_permission_to_lambda(destination_arn, log_group_name, region, account_id)
+                        print(f"Adding subscription filter for {log_group_name}")
                         add_subscription(filter_name, logs_filter, log_group_name, destination_arn)
                     else:
+                        print(f"Adding subscription filter for {log_group_name}")
                         add_subscription(filter_name, logs_filter, log_group_name, destination_arn, role_arn)
                     break # no need to continue the loop if we find a match for the log group
 
 def add_subscription(filter_name: str, logs_filter: str, log_group_to_subscribe: str, destination_arn: str, role_arn: str = None) -> str:
     '''Add subscription to CloudWatch log group'''
-    print(f"Adding subscription filter for {log_group_to_subscribe}")
     try:
         if role_arn is None:
             cloudwatch_logs.put_subscription_filter(

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -16,7 +16,7 @@ Metadata:
       - cloudwatch
       - lambda
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 2.0.2
+    SemanticVersion: 2.0.3
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -56,8 +56,12 @@ Parameters:
     Default: false
   RegexPattern:
     Type: String
-    Description: Loggroup name regex pattern
+    Description: Comma-separated list of Loggroup name regex pattern
     Default: \/aws\/lambda\/.*
+  LogGroupPermissionPreFix:
+    Type: String
+    Description: instead creating one permission for each log group in the destination lambda, the code will take the prefix that you set in the parameter and create 1 permission for all of the log groups that match the prefix
+    Default: ""
   FunctionMemorySize:
     Type: Number
     Description: Lambda function memory limit
@@ -81,10 +85,6 @@ Conditions:
       - Fn::Equals:
           - Ref: NotificationEmail
           - ''
-  ScanOldLogGroups:
-    Fn::Equals:
-      - Ref: ScanOldLogGroups
-      - 'true'
 Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -136,6 +136,8 @@ Resources:
             Ref: DestinationType
           SCAN_OLD_LOGGROUPS:
             Ref: ScanOldLogGroups
+          LOG_GROUP_PERMISSION_PREFIX:
+            Ref: LogGroupPermissionPreFix
       Policies:
         - Statement:
             - Sid: CXLambdaUpdateConfig
@@ -182,7 +184,6 @@ Resources:
 
   LambdaTrigger:
     Type: Custom::LambdaTrigger
-    Condition: ScanOldLogGroups
     DependsOn: LambdaFunction
     Properties:
       ServiceToken: !GetAtt LambdaFunction.Arn


### PR DESCRIPTION
Right now the lambda will add permission for each of the log groups to the destination lambda, this can hit an AWS limitation for the number of permissions. Added a new variable `LogGroupPermissionPreFix` so that when it's defined the lambda will create permissions using the log group prefix from the parameter and wildcard (*) instead of creating 1 permission for each log group this will help avoid the AWS limitation.           
ReWrite most of the Python lambda code for it to work with the new parameter.
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)