### PR TITLE
fix: fix sqs retention period in resource-metadata-sqs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,17 @@ jobs:
         name: Publish
         run: sam publish --template packaged.yaml
 
-      - if: ${{ matrix.package != 'helper' }}
+      - if: ${{ matrix.package == 'resource-metadata-sqs' }}
+        name: StoreMultiFunction
+        run: |
+          aws s3 cp \
+            $(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "CollectorLambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml) \
+            s3://${{ env.AWS_SERVERLESS_BUCKET }}-${{ env.AWS_DEFAULT_REGION }}/${{ matrix.package }}-collector.zip
+          aws s3 cp \
+            $(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "GeneratorLambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml) \
+            s3://${{ env.AWS_SERVERLESS_BUCKET }}-${{ env.AWS_DEFAULT_REGION }}/${{ matrix.package }}-generator.zip
+
+      - if: ${{ !contains(fromJson('["helper", "resource-metadata-sqs"]'), matrix.package) }}
         name: Store
         run: |
           aws s3 cp \

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 0.1.1 / 31.01.2025
 * [Fix] Remove non-existent function from SAM template and hardcode message retention period to 1 hour instead of using the resource ttl.
+* [Fix] Update GitHub Actions publish step to store multi-function SAM template.
 
 ### 0.1.0 / 28.01.2025
 * First version

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.1.1 / 31.01.2025
+* [Fix] Remove non-existent function from SAM template and hardcode message retention period to 1 hour instead of using the resource ttl.
+
 ### 0.1.0 / 28.01.2025
 * First version
 <!-- To add a new entry write: -->

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -274,7 +274,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       VisibilityTimeout: 900
-      MessageRetentionPeriod: !Multiply [!Ref ResourceTtlMinutes, 60]
+      MessageRetentionPeriod: 3600
 
   CollectorLambdaFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
# Description

Fixes failed release in https://github.com/coralogix/coralogix-aws-serverless/actions/runs/13070393156/job/36470627029

It turns out that you can't do any math in CloudFormation by design and need to use the Custom Resource for it. Instead of doing that just for aligning `ResourceTtlMinutes` with `MessageRetentionPeriod` in SQS, I decided to set it fixed for 1 hour which is not long enough to process outdated metadata and not short enough to dissappear before `generator-lambda` workers process it.

# How Has This Been Tested?

Yes, by using `sam validate`

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)