### PR TITLE
fix: reduce CloudTrail bucket name length

### DIFF
--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.1.2 / 04.02.2025
+* [Fix] Adjust CloudTrail S3 bucket name to fit the character limit (<=63 characters)
+
 ### 0.1.1 / 31.01.2025
 * [Fix] Remove non-existent function from SAM template and hardcode message retention period to 1 hour instead of using the resource ttl.
 * [Fix] Update GitHub Actions publish step to store multi-function SAM template.

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-collector",
   "title": "AWS Resource Collector Lambda function for Coralogix",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "AWS Lambda function to collect AWS EC2/Lambda resources for further processing",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-generator",
   "title": "AWS Resource Generator Lambda function for Coralogix",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "AWS Lambda function to generate AWS EC2/Lambda resources for Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -538,7 +538,7 @@ Resources:
     Condition: ShouldCreateCloudTrail
     DeletionPolicy: Retain
     Properties:
-      BucketName: !Sub ${AWS::StackName}-cloudtrail-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub metadata-cloudtrail-${AWS::AccountId}-${AWS::Region}
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -14,7 +14,7 @@ Metadata:
       - metadata
       - sqs
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.1.0
+    SemanticVersion: 0.1.2
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description

Adjust CloudTrail S3 bucket name to fit the character limit (<=63 characters). Otherwise, there is a risk of the CloudFormation stack name being too long to fit in the S3 bucket name, which gives us the error when we attempt to create the bucket

# How Has This Been Tested?

Deployed new template and verified that the bucket name gets created no matter how long the stack name is.

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)