### PR TITLE
fix: [CDS-1876] rewrite batch collection of EC2 instances to avoid exceeding the SQS message size limit

### DIFF
--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.1.3 / 17.02.2025
+* [Fix] CDS-1876 rewrite batch collection of EC2 instances to avoid exceeding the SQS message size limit
+
 ### 0.1.2 / 04.02.2025
 * [Fix] Adjust CloudTrail S3 bucket name to fit the character limit (<=63 characters)
 

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -6,7 +6,7 @@ export const collectEc2Resources = async function* () {
     console.info("Collecting list of EC2 instances");
     const CHUNK_SIZE = 50;
 
-    for await (const page of paginateDescribeInstances({ client: ec2Client })) {
+    for await (const page of paginateDescribeInstances({ client: ec2Client }, {})) {
         if (page.Reservations) {
             const pageInstances = page.Reservations.flatMap(r => r.Instances);
 

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -3,11 +3,18 @@ import { EC2Client, paginateDescribeInstances } from '@aws-sdk/client-ec2'
 const ec2Client = new EC2Client();
 
 export const collectEc2Resources = async function* () {
-    for await (const page of paginateDescribeInstances({ client: ec2Client }, { MaxItems: 50 })) {
+    console.info("Collecting list of EC2 instances");
+    const CHUNK_SIZE = 50;
+
+    for await (const page of paginateDescribeInstances({ client: ec2Client })) {
         if (page.Reservations) {
             const pageInstances = page.Reservations.flatMap(r => r.Instances);
-            if (pageInstances.length > 0) {
-                yield pageInstances;
+
+            // Chunk the instances array into groups of CHUNK_SIZE to avoid exceeding the SQS message size limit
+            for (let i = 0; i < pageInstances.length; i += CHUNK_SIZE) {
+                const chunk = pageInstances.slice(i, i + CHUNK_SIZE);
+                console.info(`Yielding chunk with ${chunk.length} instances`);
+                yield chunk;
             }
         }
     }

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-collector",
   "title": "AWS Resource Collector Lambda function for Coralogix",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AWS Lambda function to collect AWS EC2/Lambda resources for further processing",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-generator",
   "title": "AWS Resource Generator Lambda function for Coralogix",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AWS Lambda function to generate AWS EC2/Lambda resources for Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -14,7 +14,7 @@ Metadata:
       - metadata
       - sqs
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.1.2
+    SemanticVersion: 0.1.3
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description

This will fix the batching of EC2 instances on the `collector` side to fix the bug, where we exceed the SQS message size limit.

## The Bug

```
Invoke Error 	{
    "errorType": "InvalidParameterValue",
    "errorMessage": "One or more parameters are invalid. Reason: Message must be shorter than 262144 bytes.",
    "name": "InvalidParameterValue",
    "$fault": "client",
    "$metadata": {
        "httpStatusCode": 400,
        "requestId": "...",
        "attempts": 1,
        "totalRetryDelay": 0
    }
```

This happens when we have more than ~80 EC2 instances in the target AWS region. The reason why it happens, because the `collector` doesn't split the EC2 instances into batches (50 instances per batch) the way we've expected.

The `MaxItems: 50` parameter in the EC2 API doesn't work the way we expect. For EC2's DescribeInstances API, the `MaxItems` parameter actually controls the number of "Reservations" per page, not the number of instances.

To fix it, I ended up batching instances "manually" to ensure it's limited and fits max SQS message size (50 instances =~ 145-150kb.)

# How Has This Been Tested?

1. Reproduced the error by spinning up 100 instances
2. Updated Lambda and re-run `collector` to see the error fixed
3. Ensured `generator` handles the incoming SQS messages well

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)