### PR TITLE
fix: [CDS-1876] reduce EC2 batch size by half

### DIFF
--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.1.4 / 19.02.2025
+* [Fix] CDS-1876 Reduce EC2 batch size by half (50 --> 25 instances)
+
 ### 0.1.3 / 17.02.2025
 * [Fix] CDS-1876 rewrite batch collection of EC2 instances to avoid exceeding the SQS message size limit
 

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## resource-metadata-sqs
 
 ### 0.1.4 / 19.02.2025
-* [Fix] CDS-1876 Reduce EC2 batch size by half (50 --> 25 instances)
+* [Fix] CDS-1876 Reduce EC2 batch size by half as default (50 --> 25) and let the user configure the chunk size
 
 ### 0.1.3 / 17.02.2025
 * [Fix] CDS-1876 rewrite batch collection of EC2 instances to avoid exceeding the SQS message size limit

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.1.3 / 17.02.2025
+* [Fix] CDS-1876 rewrite batch collection of EC2 instances to avoid exceeding the SQS message size limit
+
 ### 0.1.2 / 04.02.2025
 * [Fix] Adjust CloudTrail S3 bucket name to fit the character limit (<=63 characters)
 

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -6,7 +6,7 @@ export const collectEc2Resources = async function* () {
     console.info("Collecting list of EC2 instances");
     const CHUNK_SIZE = 50;
 
-    for await (const page of paginateDescribeInstances({ client: ec2Client })) {
+    for await (const page of paginateDescribeInstances({ client: ec2Client }, {})) {
         if (page.Reservations) {
             const pageInstances = page.Reservations.flatMap(r => r.Instances);
 

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -1,18 +1,24 @@
+import assert from 'assert'
 import { EC2Client, paginateDescribeInstances } from '@aws-sdk/client-ec2'
 
 const ec2Client = new EC2Client();
 
+const validateAndExtractConfiguration = () => {
+    assert(process.env.EC2_CHUNK_SIZE, "EC2_CHUNK_SIZE env var missing!")
+    const chunkSize = parseInt(process.env.EC2_CHUNK_SIZE, 10)
+    return { chunkSize };
+};
+const { chunkSize } = validateAndExtractConfiguration();
+
 export const collectEc2Resources = async function* () {
     console.info("Collecting list of EC2 instances");
-    const CHUNK_SIZE = 25;
 
     for await (const page of paginateDescribeInstances({ client: ec2Client }, {})) {
         if (page.Reservations) {
             const pageInstances = page.Reservations.flatMap(r => r.Instances);
 
-            // Chunk the instances array into groups of CHUNK_SIZE to avoid exceeding the SQS message size limit
-            for (let i = 0; i < pageInstances.length; i += CHUNK_SIZE) {
-                const chunk = pageInstances.slice(i, i + CHUNK_SIZE);
+            for (let i = 0; i < pageInstances.length; i += chunkSize) {
+                const chunk = pageInstances.slice(i, i + chunkSize);
                 console.info(`Yielding chunk with ${chunk.length} instances`);
                 yield chunk;
             }

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -4,7 +4,7 @@ const ec2Client = new EC2Client();
 
 export const collectEc2Resources = async function* () {
     console.info("Collecting list of EC2 instances");
-    const CHUNK_SIZE = 50;
+    const CHUNK_SIZE = 25;
 
     for await (const page of paginateDescribeInstances({ client: ec2Client }, {})) {
         if (page.Reservations) {

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -3,11 +3,18 @@ import { EC2Client, paginateDescribeInstances } from '@aws-sdk/client-ec2'
 const ec2Client = new EC2Client();
 
 export const collectEc2Resources = async function* () {
-    for await (const page of paginateDescribeInstances({ client: ec2Client }, { MaxItems: 50 })) {
+    console.info("Collecting list of EC2 instances");
+    const CHUNK_SIZE = 50;
+
+    for await (const page of paginateDescribeInstances({ client: ec2Client })) {
         if (page.Reservations) {
             const pageInstances = page.Reservations.flatMap(r => r.Instances);
-            if (pageInstances.length > 0) {
-                yield pageInstances;
+
+            // Chunk the instances array into groups of CHUNK_SIZE to avoid exceeding the SQS message size limit
+            for (let i = 0; i < pageInstances.length; i += CHUNK_SIZE) {
+                const chunk = pageInstances.slice(i, i + CHUNK_SIZE);
+                console.info(`Yielding chunk with ${chunk.length} instances`);
+                yield chunk;
             }
         }
     }

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-collector",
   "title": "AWS Resource Collector Lambda function for Coralogix",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AWS Lambda function to collect AWS EC2/Lambda resources for further processing",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-collector",
   "title": "AWS Resource Collector Lambda function for Coralogix",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AWS Lambda function to collect AWS EC2/Lambda resources for further processing",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-generator",
   "title": "AWS Resource Generator Lambda function for Coralogix",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AWS Lambda function to generate AWS EC2/Lambda resources for Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-generator",
   "title": "AWS Resource Generator Lambda function for Coralogix",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AWS Lambda function to generate AWS EC2/Lambda resources for Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -14,7 +14,7 @@ Metadata:
       - metadata
       - sqs
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.1.2
+    SemanticVersion: 0.1.3
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -41,6 +41,7 @@ Metadata:
           - NotificationEmail
           - ExcludedEC2ResourceType
           - ExcludedLambdaResourceType
+          - EC2ChunkSize
       - Label:
           default: Lambda Configuration
         Parameters:
@@ -92,6 +93,8 @@ Metadata:
         default: Is EC2 Resource Type Excluded?
       ExcludedLambdaResourceType:
         default: Is Lambda Resource Type Excluded?
+      EC2ChunkSize:
+        default: EC2 Chunk Size
 Parameters:
   CoralogixRegion:
     Type: String
@@ -156,6 +159,12 @@ Parameters:
     Type: Number
     Description: Once a resource is collected, how long should it remain valid?
     Default: 60
+  EC2ChunkSize:
+    Type: Number
+    Description: Number of EC2 instances to process in each batch
+    Default: 25
+    MinValue: 1
+    MaxValue: 40
   FunctionArchitecture:
     Type: String
     Description: Lambda function architecture [x86_64, arm64]
@@ -308,6 +317,8 @@ Resources:
               - 'True'
               - 'False'
           METADATA_QUEUE_URL: !Ref MetadataQueue
+          EC2_CHUNK_SIZE:
+            Ref: EC2ChunkSize
       Events:
         ScheduledEvent:
           Type: Schedule

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -14,7 +14,7 @@ Metadata:
       - metadata
       - sqs
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.1.3
+    SemanticVersion: 0.1.4
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description

```
INFO    Yielding chunk with 50 instances
INFO    Yielding chunk with 50 instances
INFO    Yielding chunk with 25 instances
INFO    Sending collector.ec2 resources batch to SQS
INFO    Sent collector.ec2 resources batch to SQS
INFO    Sending collector.ec2 resources batch to SQS
ERROR    Invoke Error     {""errorType"":""InvalidParameterValue"",""errorMessage"":""One or more parameters are invalid. Reason: Message must be shorter than 262144 bytes"}
```

On one of our environments, while the 1st batch with 50 instances gets sent successfully, the 2nd one with the same number of instances hits the message size limit, which wasn't expected.

This fix will:

1. Set the EC2 chunk size as the parameter, so it can be configured by customers.
2. By default, reduce the EC2 batch size by half (50 --> 25 instances), so it won't happen in any case.

# How Has This Been Tested?

Run the change on the AWS region with 100 EC2 instances to ensure it gets splitted as expected.

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)