### PR TITLE
feat: CDS-1915 add mx-central-1

### DIFF
--- a/infra/terragrunt.hcl
+++ b/infra/terragrunt.hcl
@@ -3,7 +3,8 @@ locals {
     "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "eu-north-1",
     "us-east-1", "us-east-2", "us-west-1", "us-west-2",
     "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-east-1",
-    "ca-central-1", "eu-south-1"
+    "ca-central-1", "eu-south-1",
+    "mx-central-1"
   ]
 }
 


### PR DESCRIPTION
# Description

This will add the serverless repo mirror to the new AWS region `mx-central-1`, fixing CDS-1915

# Checklist:

- [ ] I have updated the versions in the changed module in the template index.js and package.json files.
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)