### PR TITLE
fix: CDS-1949 rewrite the coralogix-reporter to handle new OpenSearch API

### DIFF
--- a/src/coralogix-reporter/CHANGELOG.md
+++ b/src/coralogix-reporter/CHANGELOG.md
@@ -2,12 +2,23 @@
 
 ## coralogix-reporter
 
-### 2.0.0 / 12.12.2023
-* [Update] moved from elasticsearch to opensearch, namechange to coralogix-reporter
-* [Update] upgrade nodejs from 16.x to 20.x
+### 3.0.0 / 13.03.2025
+* [Fix] Rewrite the function from callback to async/await. This will resolve a critical issue, where the Lambda exits before the e-mail is being sent
+* [Update] Replace API endpoints + CX region names to the new ones
+* [Update] Rewrite the API logic to fit the new OpenSearch endpoints – default var + authorization header
+* [Feature] Improve templating by parsing the API response's JSON and exit the function on empty result of templating
+* [Fix] Add more logs and error handling to make the function easier to troubleshoot in case when it's not working as expected
+* [Feature] Rake the search index configurable
+* [Fix] Remove the unused IAM policy from the SAM template
+* [Update] Upgrade nodejs from 20.x to 22.x
+* [Update] Upgrade dependencies
+
+### 2.0.2 / 1.03.2024
+* [Fix] Add semantic versioning
 
 ### 2.0.1 / 1.03.2024
 * [Fix] Add SES sendmail policy to lambda function
 
-### 2.0.2 / 1.03.2024
-* [Fix] Add semantic versioning
+### 2.0.0 / 12.12.2023
+* [Update] moved from elasticsearch to opensearch, namechange to coralogix-reporter
+* [Update] upgrade nodejs from 16.x to 20.x

--- a/src/coralogix-reporter/index.js
+++ b/src/coralogix-reporter/index.js
@@ -21,7 +21,7 @@ const jsonexport = require("jsonexport");
 const nodemailer = require("nodemailer");
 
 // Check Lambda function parameters
-assert(process.env.logs_query_key, "No Logs Query key!");
+assert(process.env.api_key, "No API key!");
 assert(process.env.query, "No OpenSearch query!");
 assert(process.env.template, "No report template!");
 assert(process.env.sender, "No report sender!");
@@ -47,7 +47,7 @@ async function handler(event, context) {
         maxRetries: 3,
         requestTimeout: requestTimeout,
         headers: {
-            'Authorization': `Bearer ${process.env.logs_query_key}`
+            'Authorization': `Bearer ${process.env.api_key}`
         }
     });
 

--- a/src/coralogix-reporter/index.js
+++ b/src/coralogix-reporter/index.js
@@ -22,6 +22,7 @@ const nodemailer = require("nodemailer");
 
 // Check Lambda function parameters
 assert(process.env.api_key, "No API key!");
+assert(process.env.index, "No OpenSearch index!");
 assert(process.env.query, "No OpenSearch query!");
 assert(process.env.template, "No report template!");
 assert(process.env.sender, "No report sender!");
@@ -62,7 +63,7 @@ async function handler(event, context) {
 
         console.log('Executing OpenSearch query');
         const result = await searchClient.search({
-            index: "*",
+            index: process.env.index,
             body: query
         });
 

--- a/src/coralogix-reporter/index.js
+++ b/src/coralogix-reporter/index.js
@@ -6,7 +6,7 @@
  * @link        https://coralogix.com/
  * @copyright   Coralogix Ltd.
  * @licence     Apache-2.0
- * @version     2.0.2
+ * @version     3.0.0
  * @since       1.0.0
  */
 

--- a/src/coralogix-reporter/index.js
+++ b/src/coralogix-reporter/index.js
@@ -26,8 +26,8 @@ assert(process.env.query, "No OpenSearch query!");
 assert(process.env.template, "No report template!");
 assert(process.env.sender, "No report sender!");
 assert(process.env.recipient, "No recipient sender!");
+assert(process.env.coralogix_endpoint, "No Coralogix endpoint!");
 const query = JSON.parse(process.env.query);
-const coralogixUrl = process.env.CORALOGIX_URL || "https://api.coralogix.com/data/os-api";
 const requestTimeout = process.env.request_timeout ? parseInt(process.env.request_timeout) : 30000;
 const subject = process.env.subject || "Coralogix OpenSearch Report";
 
@@ -43,7 +43,7 @@ async function handler(event, context) {
 
     console.log('Initializing OpenSearch client');
     const searchClient = new opensearch.Client({
-        node: coralogixUrl,
+        node: process.env.coralogix_endpoint,
         maxRetries: 3,
         requestTimeout: requestTimeout,
         headers: {
@@ -53,7 +53,7 @@ async function handler(event, context) {
 
     try {
         console.log('Configuration:', {
-            coralogixUrl,
+            coralogixEndpoint: process.env.coralogix_endpoint,
             requestTimeout,
             sender: process.env.sender,
             recipient: process.env.recipient,
@@ -127,7 +127,7 @@ async function handler(event, context) {
             ]
         });
 
-        console.log('Email sent successfully:');
+        console.log('Email sent successfully');
         return `Report sent successfully: ${JSON.stringify(info)}`;
     } catch (error) {
         console.error('Error in handler:', error);

--- a/src/coralogix-reporter/index.js
+++ b/src/coralogix-reporter/index.js
@@ -28,9 +28,8 @@ assert(process.env.template, "No report template!");
 assert(process.env.sender, "No report sender!");
 assert(process.env.recipient, "No recipient sender!");
 assert(process.env.coralogix_endpoint, "No Coralogix endpoint!");
-const query = JSON.parse(process.env.query);
-const requestTimeout = process.env.request_timeout ? parseInt(process.env.request_timeout) : 30000;
-const subject = process.env.subject || "Coralogix OpenSearch Report";
+assert(process.env.subject, "No subject!");
+assert(process.env.request_timeout, "No request timeout!");
 
 /**
  * @description Lambda function handler
@@ -46,7 +45,7 @@ async function handler(event, context) {
     const searchClient = new opensearch.Client({
         node: process.env.coralogix_endpoint,
         maxRetries: 3,
-        requestTimeout: requestTimeout,
+        requestTimeout: process.env.request_timeout,
         headers: {
             'Authorization': `Bearer ${process.env.api_key}`
         }
@@ -55,7 +54,7 @@ async function handler(event, context) {
     try {
         console.log('Configuration:', {
             coralogixEndpoint: process.env.coralogix_endpoint,
-            requestTimeout,
+            requestTimeout: process.env.request_timeout,
             sender: process.env.sender,
             recipient: process.env.recipient,
             region: process.env.AWS_REGION
@@ -64,7 +63,7 @@ async function handler(event, context) {
         console.log('Executing OpenSearch query');
         const result = await searchClient.search({
             index: process.env.index,
-            body: query
+            body: JSON.parse(process.env.query)
         });
 
         let responseBody;
@@ -118,7 +117,7 @@ async function handler(event, context) {
         const info = await transporter.sendMail({
             from: process.env.sender,
             to: process.env.recipient,
-            subject: subject,
+            subject: process.env.subject,
             text: 'Please find the attached report.',
             attachments: [
                 {

--- a/src/coralogix-reporter/package.json
+++ b/src/coralogix-reporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-reporter",
   "title": "AWS Lambda function for Coralogix Reporting",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "AWS Lambda function for reports generated from Coralogix OpenSearch API sending",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",
@@ -12,13 +12,18 @@
     "url": "https://coralogix.com"
   },
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "contributors": [
     {
       "name": "Ryan Tan",
       "email": "ryan.tan@coralogix.com",
       "url": "https://github.com/ryantanjunming"
+    },
+    {
+      "name": "Mikhail Chinkov",
+      "email": "mikhail.chinkov@coralogix.com",
+      "url": "https://github.com/cazorla19"
     }
   ],
   "keywords": [
@@ -39,14 +44,15 @@
     "url": "https://github.com/coralogix/coralogix-aws-serverless/issues"
   },
   "dependencies": {
-    "@aws-sdk/client-ses": "^3.470.0",
-    "@opensearch-project/opensearch": "^2.4.0",
+    "@aws-sdk/client-ses": "^3.758.0",
+    "@opensearch-project/opensearch": "^3.4.0",
     "jmespath-plus": "^0.1.7",
     "jsonexport": "^3.2.0",
-    "nodemailer": "^6.9.7"
+    "nodemailer": "^6.10.0"
   },
   "files": [
     "LICENSE",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -86,6 +86,11 @@ Parameters:
     MinLength: 1
     MaxLength: 78
     Default: Coralogix Report
+  Index:
+    Type: String
+    Description: OpenSearch index
+    MinLength: 1
+    Default: '*'
   Query:
     Type: String
     Description: OpenSearch query
@@ -145,6 +150,8 @@ Resources:
               - LogUrl
           api_key:
             Ref: ApiKey
+          index:
+            Ref: Index
           query:
             Ref: Query
           template:

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -155,7 +155,7 @@ Resources:
             Ref: Recipient
           subject:
             Ref: Subject
-          requestTimeout:
+          request_timeout:
             Ref: RequestTimeout
       Policies:
         - Version: '2012-10-17'

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -18,7 +18,7 @@ Metadata:
       - ses
       - email
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 2.0.2
+    SemanticVersion: 3.0.0
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
 Parameters:
   CoralogixRegion:
@@ -134,7 +134,7 @@ Resources:
       Description: Generate report from Coralogix OpenSearch API and send it by email.
       CodeUri: .
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Architectures:
         - Ref: FunctionArchitecture
       MemorySize:

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -32,9 +32,9 @@ Parameters:
       - US1
       - US2
     Default: Europe
-  LogsQueryKey:
+  ApiKey:
     Type: String
-    Description: The Coralogix Logs Query Key found under Data Flow > API Keys > Logs Query Key.
+    Description: The Coralogix API Key found under Data Flow > API Keys > Personal Keys.
     NoEcho: true
   FunctionArchitecture:
     Type: String
@@ -143,8 +143,8 @@ Resources:
               - CoralogixRegionMap
               - Ref: CoralogixRegion
               - LogUrl
-          logs_query_key:
-            Ref: LogsQueryKey
+          api_key:
+            Ref: ApiKey
           query:
             Ref: Query
           template:

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -106,18 +106,18 @@ Parameters:
     Default: ''
 Mappings:
   CoralogixRegionMap:
-    Europe:
-      LogUrl: https://coralogix-esapi.coralogix.com:9443
-    Europe2:
-      LogUrl: https://es-api.eu2.coralogix.com:9443
-    India:
-      LogUrl: https://es-api.app.coralogix.in:9443
-    Singapore:
-      LogUrl: https://es-api.coralogixsg.com:9443
-    US:
-      LogUrl: https://esapi.coralogix.us:9443
+    EU1:
+      LogUrl: https://api.coralogix.com/data/os-api
+    EU2:
+      LogUrl: https://api.eu2.coralogix.com/data/os-api
+    AP1:
+      LogUrl: https://api.app.coralogix.in/data/os-api
+    AP2:
+      LogUrl: https://api.coralogixsg.com/data/os-api
+    US1:
+      LogUrl: https://api.coralogix.us/data/os-api
     US2:
-      LogUrl: https://es-api.cx498.coralogix.com:9443
+      LogUrl: https://api.cx498.coralogix.com/data/os-api
 Conditions:
   IsNotificationEnabled: !Not [!Equals [!Ref NotificationEmail, '']]
   IsScheduleEnabled: !Not [!Equals [!Ref ScheduleEnable, 'false']] 
@@ -138,7 +138,7 @@ Resources:
         Ref: FunctionTimeout
       Environment:
         Variables:
-          CORALOGIX_URL:
+          coralogix_endpoint:
             Fn::FindInMap:
               - CoralogixRegionMap
               - Ref: CoralogixRegion

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -172,9 +172,6 @@ Resources:
                 - 'ses:SendEmail'
                 - 'ses:SendRawEmail'
               Resource: '*'
-        - SESCrudPolicy:
-            IdentityName:
-              Ref: Sender
       EventInvokeConfig:
         DestinationConfig:
           OnFailure:

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -23,13 +23,13 @@ Metadata:
 Parameters:
   CoralogixRegion:
     Type: String
-    Description: The Coralogix location region, possible options are [Europe, Europe2, India, Singapore, US, US2]
+    Description: The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US1, US2]
     AllowedValues:
-      - Europe
-      - Europe2
-      - India
-      - Singapore
-      - US
+      - EU1
+      - EU2
+      - AP1
+      - AP2
+      - US1
       - US2
     Default: Europe
   LogsQueryKey:


### PR DESCRIPTION
# Description

Fixes CDS-1949

Changeset:

* [Fix] Rewrite the function from callback to async/await. This will resolve a critical issue, where the Lambda exits before the e-mail is being sent
* [Update] Replace API endpoints + CX region names to the new ones
* [Update] Rewrite the API logic to fit the new OpenSearch endpoints – default var + authorization header
* [Feature] Improve templating by parsing the API response's JSON and exit the function on empty result of templating
* [Fix] Add more logs and error handling to make the function easier to troubleshoot in case when it's not working as expected
* [Feature] Rake the search index configurable
* [Fix] Remove the unused IAM policy from the SAM template 
* [Update] Upgrade nodejs from 20.x to 22.x
* [Update] Upgrade dependencies

# How Has This Been Tested?

Run the result in CloudFormation+Lambda test

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect module (e.g. it's readme file change)