### PR TITLE
fix: CoralogixRegion must be one of AllowedValues

### DIFF
--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -31,7 +31,7 @@ Parameters:
       - AP2
       - US1
       - US2
-    Default: Europe
+    Default: EU1
   ApiKey:
     Type: String
     Description: The Coralogix API Key found under Data Flow > API Keys > Personal Keys.


### PR DESCRIPTION
# Description

This will fix the SAM template error:

```
Error: SAM template is invalid. It cannot be deployed using AWS CloudFormation due to the following validation error: Parameter 'CoralogixRegion' must be one of AllowedValues
```

Didn't update the Changelog, since the last version wasn't actually released.

# How Has This Been Tested?

run `sam validate` to ensure I no longer get errors like this one.

# Checklist:
- [ ] I have updated the versions in the changed module in the template index.js and package.json files.
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect module (e.g. it's readme file change)