### PR TITLE
CDS-1924 recover serverless buckets creation

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -49,6 +49,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
+      - run: aws --version
+        shell: bash
+
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2
         with:

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'infra/**'
   pull_request:
+    paths:
+      - 'infra/**'
 
 env:
   AWS_DEFAULT_REGION: eu-central-1

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -31,7 +31,7 @@ jobs:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
-          tg_command: 'terragrunt hclfmt --check --diff'
+          tg_command: 'hclfmt --terragrunt-check --terragrunt-diff'
 
   plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -50,7 +50,9 @@ jobs:
         uses: gruntwork-io/terragrunt-action@v2
         env:
           INPUT_PRE_EXEC_1: |
-            snap install aws-cli --classic
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            ./aws/install
         with:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -50,7 +50,7 @@ jobs:
         uses: gruntwork-io/terragrunt-action@v2
         env:
           INPUT_PRE_EXEC_1: |
-            apk add --no-cache aws-cli
+            snap install aws-cli --classic
         with:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -12,6 +12,10 @@ on:
       - 'infra/**'
 
 env:
+  AWS_CLI_INSTALL: |
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    ./aws/install
   AWS_DEFAULT_REGION: eu-central-1
   AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
   tf_version: '1.11.2'
@@ -49,10 +53,7 @@ jobs:
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2
         env:
-          INPUT_PRE_EXEC_1: |
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            ./aws/install
+          INPUT_PRE_EXEC_1: ${{ env.AWS_CLI_INSTALL }}
         with:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
@@ -75,6 +76,8 @@ jobs:
 
       - name: Deploy
         uses: gruntwork-io/terragrunt-action@v2
+        env:
+          INPUT_PRE_EXEC_1: ${{ env.AWS_CLI_INSTALL }}
         with:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -63,7 +63,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [ plan ]
-    if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
+    # if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
     steps:
       - name: 'Checkout'
         uses: actions/checkout@main

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -63,7 +63,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [ plan ]
-    # if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
+    if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
     steps:
       - name: 'Checkout'
         uses: actions/checkout@main

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -8,23 +8,35 @@ on:
     paths:
       - 'infra/**'
   pull_request:
-    types: [closed]
-    branches: [master]
-    paths:
-      - 'infra/**'
 
 env:
   AWS_DEFAULT_REGION: eu-central-1
+  TF_VAR_s3_bucket_name_prefix: coralogix-serverless-repo
+  tf_version: '1.11.2'
+  tg_version: '0.76.1'
+  working_dir: 'infra'
 
 jobs:
-  infrastructure:
-    name: Infrastructure
+  checks:
     runs-on: ubuntu-latest
-    env:
-      AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: 'Checkout'
+        uses: actions/checkout@main
+
+      - name: Check terragrunt HCL
+        uses: gruntwork-io/terragrunt-action@v2
+        with:
+          tf_version: ${{ env.tf_version }}
+          tg_version: ${{ env.tg_version }}
+          tg_dir: ${{ env.working_dir }}
+          tg_command: 'terragrunt hclfmt --check --diff'
+
+  plan:
+    runs-on: ubuntu-latest
+    needs: [ checks ]
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@main
 
       - uses: aws-actions/setup-sam@v2
         with:
@@ -36,17 +48,36 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
-      - name: Init
-        working-directory: infra/
-        run: terragrunt init
+      - name: Plan
+        uses: gruntwork-io/terragrunt-action@v2
+        with:
+          tf_version: ${{ env.tf_version }}
+          tg_version: ${{ env.tg_version }}
+          tg_dir: ${{ env.working_dir }}
+          tg_command: 'plan'
 
-      - name: Validate
-        working-directory: infra/
-        run: terragrunt validate
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [ plan ]
+    if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@main
 
-      - name: Apply
-        working-directory: infra/
-        run: |
-          terragrunt apply \
-            -var="s3_bucket_name_prefix=${{ env.AWS_SERVERLESS_BUCKET }}" \
-            -auto-approve
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Deploy
+        uses: gruntwork-io/terragrunt-action@v2
+        with:
+          tf_version: ${{ env.tf_version }}
+          tg_version: ${{ env.tg_version }}
+          tg_dir: ${{ env.working_dir }}
+          tg_command: 'apply'

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   AWS_DEFAULT_REGION: eu-central-1
-  TF_VAR_s3_bucket_name_prefix: coralogix-serverless-repo
+  AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
   tf_version: '1.11.2'
   tg_version: '0.76.1'
   working_dir: 'infra'

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,6 +1,8 @@
 name: Infrastructure
 
 on:
+  schedule:
+    - cron: '0 10 * * 1'  # Every Monday at 10:00 UTC
   push:
     branches: [master]
     paths:
@@ -17,10 +19,23 @@ env:
 jobs:
   infrastructure:
     name: Infrastructure
-    runs-on: aws-sam
+    runs-on: ubuntu-latest
     env:
       AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
       - name: Init
         working-directory: infra/
         run: terragrunt init

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -40,20 +40,17 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@main
 
-      - name: install-aws-cli
-        uses: unfor19/install-aws-cli-action@v1
-
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
-      - run: aws --version
-        shell: bash
-
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2
+        env:
+          INPUT_PRE_EXEC_1: |
+            apk add --no-cache aws-cli
         with:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
@@ -67,9 +64,6 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@main
-
-      - name: install-aws-cli
-        uses: unfor19/install-aws-cli-action@v1
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -31,7 +31,7 @@ jobs:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
-          tg_command: 'hclfmt --terragrunt-check --terragrunt-diff'
+          tg_command: 'hclfmt --check --diff'
 
   plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -40,9 +40,8 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@main
 
-      - uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
+      - name: install-aws-cli
+        uses: unfor19/install-aws-cli-action@v1
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -66,9 +65,8 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@main
 
-      - uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
+      - name: install-aws-cli
+        uses: unfor19/install-aws-cli-action@v1
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/infra/terragrunt.hcl
+++ b/infra/terragrunt.hcl
@@ -115,7 +115,7 @@ generate "buckets" {
 # Bucket in ${region} AWS region
 module "${region}" {
   source    = "terraform-aws-modules/s3-bucket/aws"
-  version   = "3.3.0"
+  version   = "4.6.0"
   providers = {
     aws = aws.${region}
   }


### PR DESCRIPTION
# Description

Fixes CDS-1924.

This will recover the automation workflow of creating serverless buckets for each AWS region.

1. Imported all existing buckets to the state, leaving zero diff between the state and "reality"
2. Created buckets for missing regions (`ap-southeast-5`, `ap-southeast-7`, `ca-west-1`)
3. Rewritten GitHub actions workflow, covering fmt-check and plan
4. Reconfigured AWS regions list, making it dynamic
5. Added the action run on weekly cron schedule, so that replica buckets for new AWS regions will be created automatically

# How Has This Been Tested?

1. Run terragrunt plan/apply multiple times locally
2. Run GitHub actions multiple times

# Checklist:
- [x] This change does not affect module (e.g. it's readme file change)