### PR TITLE
feat: enable collecting resource metadata from multiple accounts and regions

### DIFF
--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 0.2.0 / 02.04.2025
 * [Feature] CDS-1996 Add support for multiple regions and accounts
+* [Fix] Align line endings in js files to always add with semicolon (`;`)
 
 ### 0.1.4 / 19.02.2025
 * [Fix] CDS-1876 Reduce EC2 batch size by half as default (50 --> 25) and let the user configure the chunk size

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## resource-metadata-sqs
 
 ### 0.2.0 / 02.04.2025
-* [Feature] CDS-1996 Add support for multiple regions
+* [Feature] CDS-1996 Add support for multiple regions and accounts
 
 ### 0.1.4 / 19.02.2025
 * [Fix] CDS-1876 Reduce EC2 batch size by half as default (50 --> 25) and let the user configure the chunk size

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.2.0 / 02.04.2025
+* [Feature] CDS-1996 Add support for multiple regions
+
 ### 0.1.4 / 19.02.2025
 * [Fix] CDS-1876 Reduce EC2 batch size by half as default (50 --> 25) and let the user configure the chunk size
 

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -1,10 +1,10 @@
-import assert from 'assert'
-import { EC2Client, paginateDescribeInstances } from '@aws-sdk/client-ec2'
+import assert from 'assert';
+import { EC2Client, paginateDescribeInstances } from '@aws-sdk/client-ec2';
 
 
 const validateAndExtractConfiguration = () => {
-    assert(process.env.EC2_CHUNK_SIZE, "EC2_CHUNK_SIZE env var missing!")
-    const chunkSize = parseInt(process.env.EC2_CHUNK_SIZE, 10)
+    assert(process.env.EC2_CHUNK_SIZE, "EC2_CHUNK_SIZE env var missing!");
+    const chunkSize = parseInt(process.env.EC2_CHUNK_SIZE, 10);
     return { chunkSize };
 };
 const { chunkSize } = validateAndExtractConfiguration();

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -9,10 +9,10 @@ const validateAndExtractConfiguration = () => {
 };
 const { chunkSize } = validateAndExtractConfiguration();
 
-export const collectEc2Resources = async function* (region) {
+export const collectEc2Resources = async function* (region, clientConfig = {}) {
     console.info("Collecting list of EC2 instances");
 
-    const ec2Client = new EC2Client({ region });
+    const ec2Client = new EC2Client({ region, ...clientConfig });
     for await (const page of paginateDescribeInstances({ client: ec2Client }, {})) {
         if (page.Reservations) {
             const pageInstances = page.Reservations.flatMap(r => r.Instances);

--- a/src/resource-metadata-sqs/collector/ec2.js
+++ b/src/resource-metadata-sqs/collector/ec2.js
@@ -1,7 +1,6 @@
 import assert from 'assert'
 import { EC2Client, paginateDescribeInstances } from '@aws-sdk/client-ec2'
 
-const ec2Client = new EC2Client();
 
 const validateAndExtractConfiguration = () => {
     assert(process.env.EC2_CHUNK_SIZE, "EC2_CHUNK_SIZE env var missing!")
@@ -10,9 +9,10 @@ const validateAndExtractConfiguration = () => {
 };
 const { chunkSize } = validateAndExtractConfiguration();
 
-export const collectEc2Resources = async function* () {
+export const collectEc2Resources = async function* (region) {
     console.info("Collecting list of EC2 instances");
 
+    const ec2Client = new EC2Client({ region });
     for await (const page of paginateDescribeInstances({ client: ec2Client }, {})) {
         if (page.Reservations) {
             const pageInstances = page.Reservations.flatMap(r => r.Instances);

--- a/src/resource-metadata-sqs/collector/index.js
+++ b/src/resource-metadata-sqs/collector/index.js
@@ -14,15 +14,40 @@ import assert from 'assert'
 import { collectLambdaResources } from './lambda.js'
 import { collectEc2Resources } from './ec2.js';
 import { sendToSqs } from './sqs.js';
+import { STSClient, AssumeRoleCommand, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 
 const validateAndExtractConfiguration = () => {
     const excludeEC2 = String(process.env.IS_EC2_RESOURCE_TYPE_EXCLUDED).toLowerCase() === "true"
     const excludeLambda = String(process.env.IS_LAMBDA_RESOURCE_TYPE_EXCLUDED).toLowerCase() === "true"
     const regions = process.env.REGIONS?.split(',') || [process.env.AWS_REGION];
+    const roleArns = process.env.CROSSACCOUNT_IAM_ROLE_ARNS ? process.env.CROSSACCOUNT_IAM_ROLE_ARNS.split(',') : [];
 
-    return { excludeEC2, excludeLambda, regions };
+    return { excludeEC2, excludeLambda, regions, roleArns };
 }
-const { excludeEC2, excludeLambda, regions } = validateAndExtractConfiguration();
+const { excludeEC2, excludeLambda, regions, roleArns } = validateAndExtractConfiguration();
+
+// Function to assume a role using AWS SDK v3
+const assumeRole = async (roleArn) => {
+    const stsClient = new STSClient({});
+    const command = new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: 'CrossAccountLambdaSession'
+    });
+    const data = await stsClient.send(command);
+    return {
+        accessKeyId: data.Credentials.AccessKeyId,
+        secretAccessKey: data.Credentials.SecretAccessKey,
+        sessionToken: data.Credentials.SessionToken
+    };
+};
+
+// Function to get the current account ID
+const getAccountId = async (clientConfig = {}) => {
+    const stsClient = new STSClient(clientConfig);
+    const command = new GetCallerIdentityCommand({});
+    const data = await stsClient.send(command);
+    return data.Account;
+};
 
 /**
  * @description Lambda function handler
@@ -32,15 +57,36 @@ export const handler = async (_, context) => {
 
     let collectionPromises = []
 
+    // Collect resources from the current account
+    const currentAccountId = await getAccountId();
     for (const region of regions) {
         if (!excludeEC2) {
-            let ec2 = collectEc2ResourceBatches(region)
+            let ec2 = collectEc2ResourceBatches(region, currentAccountId);
             collectionPromises.push(ec2)
         }
 
         if (!excludeLambda) {
-            let lambda = collectLambdaResourceBatches(region)
+            let lambda = collectLambdaResourceBatches(region, currentAccountId);
             collectionPromises.push(lambda)
+        }
+    }
+
+    // Collect resources from other accounts if role ARNs are provided
+    for (const roleArn of roleArns) {
+        const credentials = await assumeRole(roleArn);
+        const clientConfig = { credentials };
+        const accountId = await getAccountId(clientConfig);
+
+        for (const region of regions) {
+            if (!excludeEC2) {
+                let ec2 = collectEc2ResourceBatches(region, accountId, clientConfig);
+                collectionPromises.push(ec2);
+            }
+
+            if (!excludeLambda) {
+                let lambda = collectLambdaResourceBatches(region, accountId, clientConfig);
+                collectionPromises.push(lambda);
+            }
         }
     }
 
@@ -49,31 +95,31 @@ export const handler = async (_, context) => {
     // As the generator will start queueing the Lambda API before the collector is done
     const collectedResources = await Promise.all(collectionPromises)
 
-    for (const { source, region, batches } of collectedResources) {
+    for (const { source, region, account, batches } of collectedResources) {
         for (const batch of batches) {
-            console.info(`Sending ${source}-${region} resources batch to SQS`)
-            await sendToSqs({ source, region, resources: batch })
-            console.info(`Sent ${source}-${region} resources batch to SQS`)
+            console.info(`Sending ${source} resources batch from account ${account} region ${region} to SQS`)
+            await sendToSqs({ source, region, account, resources: batch })
+            console.info(`Sent ${source} resources batch from account ${account} region ${region} to SQS`)
         }
     }
 
     console.info("Collection done")
 }
 
-const collectLambdaResourceBatches = async (region) => {
-    console.info(`Collecting Lambda resources in ${region}`)
+const collectLambdaResourceBatches = async (region, accountId, clientConfig = {}) => {
+    console.info(`Collecting Lambda resources in ${region} from account ${accountId}`)
     const batches = []
-    for await (const batch of collectLambdaResources(region)) {
+    for await (const batch of collectLambdaResources(region, clientConfig)) {
         batches.push(batch)
     }
-    return { source: "collector.lambda", region: region, batches }
+    return { source: "collector.lambda", region: region, account: accountId, batches }
 }
 
-const collectEc2ResourceBatches = async (region) => {
-    console.info(`Collecting EC2 resources in ${region}`)
+const collectEc2ResourceBatches = async (region, accountId, clientConfig = {}) => {
+    console.info(`Collecting EC2 resources in ${region} from account ${accountId}`)
     const batches = []
-    for await (const batch of collectEc2Resources(region)) {
+    for await (const batch of collectEc2Resources(region, clientConfig)) {
         batches.push(batch)
     }
-    return { source: "collector.ec2", region: region, batches }
+    return { source: "collector.ec2", region: region, account: accountId, batches }
 }

--- a/src/resource-metadata-sqs/collector/lambda.js
+++ b/src/resource-metadata-sqs/collector/lambda.js
@@ -1,17 +1,17 @@
-import { LambdaClient, paginateListFunctions } from '@aws-sdk/client-lambda'
+import { LambdaClient, paginateListFunctions } from '@aws-sdk/client-lambda';
 import { ResourceGroupsTaggingAPIClient, paginateGetResources } from '@aws-sdk/client-resource-groups-tagging-api';
 import _ from 'lodash';
 
 const validateAndExtractConfiguration = () => {
-    const includeRegex = process.env.LAMBDA_FUNCTION_INCLUDE_REGEX_FILTER ? new RegExp(_.escapeRegExp(process.env.LAMBDA_FUNCTION_INCLUDE_REGEX_FILTER)) : null
-    const excludeRegex = process.env.LAMBDA_FUNCTION_EXCLUDE_REGEX_FILTER ? new RegExp(_.escapeRegExp(process.env.LAMBDA_FUNCTION_EXCLUDE_REGEX_FILTER)) : null
-    const tagFilters = process.env.LAMBDA_FUNCTION_TAG_FILTERS ? JSON.parse(process.env.LAMBDA_FUNCTION_TAG_FILTERS) : null
+    const includeRegex = process.env.LAMBDA_FUNCTION_INCLUDE_REGEX_FILTER ? new RegExp(_.escapeRegExp(process.env.LAMBDA_FUNCTION_INCLUDE_REGEX_FILTER)) : null;
+    const excludeRegex = process.env.LAMBDA_FUNCTION_EXCLUDE_REGEX_FILTER ? new RegExp(_.escapeRegExp(process.env.LAMBDA_FUNCTION_EXCLUDE_REGEX_FILTER)) : null;
+    const tagFilters = process.env.LAMBDA_FUNCTION_TAG_FILTERS ? JSON.parse(process.env.LAMBDA_FUNCTION_TAG_FILTERS) : null;
     return { includeRegex, excludeRegex, tagFilters };
-}
+};
 const { includeRegex, excludeRegex, tagFilters } = validateAndExtractConfiguration();
 
 export const collectLambdaResources = async function* (region, clientConfig = {}) {
-    console.info(`Collecting list of functions in ${region}`)
+    console.info(`Collecting list of functions in ${region}`);
 
     let arnsMatchingTags;
     if (tagFilters) {
@@ -38,7 +38,7 @@ export const collectLambdaResources = async function* (region, clientConfig = {}
             yield pageFunctions; // Return each page as soon as it's collected
         }
     }
-}
+};
 
 const collectFunctionsArnsMatchingTagFilters = async (region, clientConfig) => {
     const input = {
@@ -50,5 +50,5 @@ const collectFunctionsArnsMatchingTagFilters = async (region, clientConfig) => {
     for await (const page of paginateGetResources({ client: resourceGroupsTaggingAPIClient }, input)) { // this uses the maximum page size of 100
         arns.push(...page.ResourceTagMappingList.map(r => r.ResourceARN));
     }
-    return arns
-}
+    return arns;
+};

--- a/src/resource-metadata-sqs/collector/lambda.js
+++ b/src/resource-metadata-sqs/collector/lambda.js
@@ -10,17 +10,17 @@ const validateAndExtractConfiguration = () => {
 }
 const { includeRegex, excludeRegex, tagFilters } = validateAndExtractConfiguration();
 
-const lambdaClient = new LambdaClient();
 const resourceGroupsTaggingAPIClient = tagFilters ? new ResourceGroupsTaggingAPIClient() : null;
 
-export const collectLambdaResources = async function* () {
-    console.info("Collecting list of functions")
+export const collectLambdaResources = async function* (region) {
+    console.info(`Collecting list of functions in ${region}`)
 
     let arnsMatchingTags;
     if (tagFilters) {
         arnsMatchingTags = new Set(await collectFunctionsArnsMatchingTagFilters());
     }
 
+    const lambdaClient = new LambdaClient({ region });
     for await (const page of paginateListFunctions({ client: lambdaClient }, { MaxItems: 50 })) {
         let pageFunctions = page.Functions;
 

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-collector",
   "title": "AWS Resource Collector Lambda function for Coralogix",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "AWS Lambda function to collect AWS EC2/Lambda resources for further processing",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/client-ec2": "^3.502.0",
     "@aws-sdk/client-lambda": "^3.502.0",
     "@aws-sdk/client-resource-groups-tagging-api": "^3.502.0",
+    "@aws-sdk/client-sts": "^3.502.0",
     "@aws-sdk/client-sqs": "^3.502.0",
     "lodash": "^4.17.21"
   },

--- a/src/resource-metadata-sqs/collector/sqs.js
+++ b/src/resource-metadata-sqs/collector/sqs.js
@@ -10,10 +10,11 @@ const { queueUrl } = validateAndExtractConfiguration();
 
 const sqsClient = new SQSClient();
 
-export const sendToSqs = async ({ source, region, resources }) => {
+export const sendToSqs = async ({ source, region, account, resources }) => {
     const message = {
         source,
         region,
+        account,
         resources,
         timestamp: new Date().toISOString()
     };

--- a/src/resource-metadata-sqs/collector/sqs.js
+++ b/src/resource-metadata-sqs/collector/sqs.js
@@ -1,8 +1,8 @@
-import assert from 'assert'
-import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+import assert from 'assert';
+import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
 
 const validateAndExtractConfiguration = () => {
-    assert(process.env.METADATA_QUEUE_URL, "METADATA_QUEUE_URL env var missing!")
+    assert(process.env.METADATA_QUEUE_URL, "METADATA_QUEUE_URL env var missing!");
     return { queueUrl: process.env.METADATA_QUEUE_URL };
 };
 

--- a/src/resource-metadata-sqs/collector/sqs.js
+++ b/src/resource-metadata-sqs/collector/sqs.js
@@ -10,9 +10,10 @@ const { queueUrl } = validateAndExtractConfiguration();
 
 const sqsClient = new SQSClient();
 
-export const sendToSqs = async ({ source, resources }) => {
+export const sendToSqs = async ({ source, region, resources }) => {
     const message = {
         source,
+        region,
         resources,
         timestamp: new Date().toISOString()
     };

--- a/src/resource-metadata-sqs/generator/common.js
+++ b/src/resource-metadata-sqs/generator/common.js
@@ -1,30 +1,30 @@
-export const schemaUrl = ""
+export const schemaUrl = "";
 
 export const extractArchitecture = architectures => {
-    const awsArchitecture = architectures?.[0]
+    const awsArchitecture = architectures?.[0];
     switch (awsArchitecture) {
         case 'x86_64':
-            return 'amd64'
+            return 'amd64';
         case 'arm64':
-            return 'arm64'
+            return 'arm64';
         default:
-            return ''
+            return '';
     }
-}
+};
 
 export const intAttr = (key, value) => ({
     key: key,
     value: {
         intValue: value,
     },
-})
+});
 
 export const stringAttr = (key, value) => ({
     key: key,
     value: {
         stringValue: value,
     },
-})
+});
 
 export const traverse = async (array, f) => {
     const results = [];
@@ -32,15 +32,15 @@ export const traverse = async (array, f) => {
         results.push(await f(array[i], i));
     }
     return results;
-}
+};
 
 export const flatTraverse = async (array, f) => {
     const results = [];
     for (var i = 0; i < array.length; i++) {
-        let result = await f(array[i], i)
+        let result = await f(array[i], i);
         if (result) {
             results.push(result);
         }
     }
     return results;
-}
+};

--- a/src/resource-metadata-sqs/generator/coralogix.js
+++ b/src/resource-metadata-sqs/generator/coralogix.js
@@ -1,13 +1,13 @@
-import assert from 'assert'
-import protoLoader from '@grpc/proto-loader'
-import grpc from '@grpc/grpc-js'
+import assert from 'assert';
+import protoLoader from '@grpc/proto-loader';
+import grpc from '@grpc/grpc-js';
 import util from 'util';
 
 const validateAndExtractConfiguration = () => {
-    assert(process.env.private_key, "No private key!")
-    const privateKey = process.env.private_key
-    assert(process.env.CORALOGIX_METADATA_URL, "No Coralogix metadata URL key!")
-    const coralogixMetadataUrl = process.env.CORALOGIX_METADATA_URL
+    assert(process.env.private_key, "No private key!");
+    const privateKey = process.env.private_key;
+    assert(process.env.CORALOGIX_METADATA_URL, "No Coralogix metadata URL key!");
+    const coralogixMetadataUrl = process.env.CORALOGIX_METADATA_URL;
     return { privateKey, coralogixMetadataUrl };
 };
 const { privateKey, coralogixMetadataUrl } = validateAndExtractConfiguration();
@@ -26,7 +26,7 @@ const createCredentials = () => {
             return callback(null, metadata);
         })
     );
-}
+};
 
 const credentials = createCredentials();
 const metadataClient = new metadataService.com.coralogix.metadata.gateway.v2.MetadataGatewayService(
@@ -37,9 +37,9 @@ metadataClient.submit[util.promisify.custom] = (input) => {
     return new Promise((resolve, reject) => {
         metadataClient.submit(input, function (err, response) {
             if (err) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(response)
+                resolve(response);
             }
         });
     });

--- a/src/resource-metadata-sqs/generator/ec2.js
+++ b/src/resource-metadata-sqs/generator/ec2.js
@@ -1,31 +1,31 @@
-import assert from 'assert'
-import { schemaUrl, stringAttr } from './common.js'
+import assert from 'assert';
+import { schemaUrl, stringAttr } from './common.js';
 
 const validateAndExtractConfiguration = () => {
-    assert(process.env.RESOURCE_TTL_MINUTES, "RESOURCE_TTL_MINUTES env var missing!")
-    const resourceTtlMinutes = parseInt(process.env.RESOURCE_TTL_MINUTES, 10)
+    assert(process.env.RESOURCE_TTL_MINUTES, "RESOURCE_TTL_MINUTES env var missing!");
+    const resourceTtlMinutes = parseInt(process.env.RESOURCE_TTL_MINUTES, 10);
     return { resourceTtlMinutes };
 };
 const { resourceTtlMinutes } = validateAndExtractConfiguration();
 
 export const generateEc2Resources = async (region, accountId, instances) => {
 
-    console.info("Generating EC2 instances")
-    const instanceResources = instances.map(i => makeEc2InstanceResource(i, region, accountId))
+    console.info("Generating EC2 instances");
+    const instanceResources = instances.map(i => makeEc2InstanceResource(i, region, accountId));
 
     instanceResources.forEach((f, index) =>
         console.debug(`Ec2Instance (${index + 1}/${instanceResources.length}): ${JSON.stringify(f)}`)
-    )
+    );
 
-    console.info(`Generated ${instanceResources.length} EC2 instances`)
+    console.info(`Generated ${instanceResources.length} EC2 instances`);
 
-    return instanceResources
-}
+    return instanceResources;
+};
 
 const makeEc2InstanceResource = (i, region, accountId) => {
     // Handle both EC2 API and EventBridge property casing
-    const instanceId = i.InstanceId || i.instanceId
-    const arn = `arn:aws:ec2:${region}:${accountId}:instance/${instanceId}`
+    const instanceId = i.InstanceId || i.instanceId;
+    const arn = `arn:aws:ec2:${region}:${accountId}:instance/${instanceId}`;
 
     const attributes = [
         stringAttr("cloud.provider", "aws"),
@@ -37,16 +37,16 @@ const makeEc2InstanceResource = (i, region, accountId) => {
         stringAttr("host.id", instanceId),
         stringAttr("host.image.id", i.ImageId || i.imageId),
         stringAttr("host.type", i.InstanceType || i.instanceType),
-    ]
+    ];
 
     // Handle tags in both formats
-    const tags = i.Tags?.items || i.Tags || i.tagSet?.items || []
-    const name = tags.find(kv => (kv.Key || kv.key) === "Name")?.Value || tags.find(kv => (kv.Key || kv.key) === "Name")?.value
+    const tags = i.Tags?.items || i.Tags || i.tagSet?.items || [];
+    const name = tags.find(kv => (kv.Key || kv.key) === "Name")?.Value || tags.find(kv => (kv.Key || kv.key) === "Name")?.value;
     if (name) {
-        attributes.push(stringAttr("host.name", name))
+        attributes.push(stringAttr("host.name", name));
     }
 
-    attributes.push(...convertEc2TagsToAttributes(tags))
+    attributes.push(...convertEc2TagsToAttributes(tags));
 
     return {
         resourceId: arn,
@@ -57,13 +57,13 @@ const makeEc2InstanceResource = (i, region, accountId) => {
             seconds: resourceTtlMinutes * 60,
             nanos: 0,
         },
-    }
-}
+    };
+};
 
 // WARNING the tags data structure is different in lambda and in ec2
 const convertEc2TagsToAttributes = tags => {
     if (!tags) {
-        return []
+        return [];
     }
     return tags.map(tag => stringAttr(`cloud.tag.${tag.Key}`, tag.Value));
-}
+};

--- a/src/resource-metadata-sqs/generator/index.js
+++ b/src/resource-metadata-sqs/generator/index.js
@@ -53,16 +53,16 @@ const processMessage = async (event, context) => {
 
     switch (event.source.toLowerCase()) {
         case "collector.ec2":
-            await generateAndSendEc2Resources(collectorId, event.region, invokedArn.accountId, event.resources)
+            await generateAndSendEc2Resources(collectorId, event.region, event.account, event.resources)
             break
         case "collector.lambda":
-            await generateAndSendLambdaResources(collectorId, event.region, event.resources)
+            await generateAndSendLambdaResources(collectorId, event.region, event.account, event.resources)
             break
         case "aws.ec2":
             await generateAndSendEc2Resources(collectorId, invokedArn.region, invokedArn.accountId, event.detail.responseElements.instancesSet.items)
             break
         case "aws.lambda":
-            await generateAndSendLambdaResources(collectorId, invokedArn.region, [event.detail.responseElements])
+            await generateAndSendLambdaResources(collectorId, invokedArn.region, invokedArn.accountId, [event.detail.responseElements])
             break
         default:
             throw new Error(`Unsupported event type: ${event.type}`)
@@ -71,9 +71,9 @@ const processMessage = async (event, context) => {
     console.info("Collection done")
 }
 
-const generateAndSendLambdaResources = async (collectorId, region, resources) => {
+const generateAndSendLambdaResources = async (collectorId, region, accountId, resources) => {
     console.info(`Generating Lambda resources from ${region}`)
-    const lambdaResources = await generateLambdaResources(region, resources)
+    const lambdaResources = await generateLambdaResources(region, accountId, resources)
     console.info("Sending Lambda resources to coralogix")
     await sendToCoralogix({ collectorId, resources: lambdaResources })
     console.info("Sent Lambda resources to coralogix")

--- a/src/resource-metadata-sqs/generator/index.js
+++ b/src/resource-metadata-sqs/generator/index.js
@@ -10,8 +10,8 @@
 
 "use strict";
 
-import { generateLambdaResources, parseLambdaFunctionArn } from './lambda.js'
-import { sendToCoralogix } from './coralogix.js'
+import { generateLambdaResources, parseLambdaFunctionArn } from './lambda.js';
+import { sendToCoralogix } from './coralogix.js';
 import { generateEc2Resources } from './ec2.js';
 
 /**
@@ -21,68 +21,68 @@ import { generateEc2Resources } from './ec2.js';
 export const handler = async (event, context) => {
     // Handle SQS events which come in a Records array
     if (event.Records) {
-        console.info(`Processing ${event.Records.length} SQS messages`)
-        const batchItemFailures = []
+        console.info(`Processing ${event.Records.length} SQS messages`);
+        const batchItemFailures = [];
 
         for (const record of event.Records) {
             // ensure partial batch processing
             try {
-                const messageBody = JSON.parse(record.body)
-                await processMessage(messageBody, context)
+                const messageBody = JSON.parse(record.body);
+                await processMessage(messageBody, context);
             } catch (error) {
-                console.error(`Failed to process message: ${error}`)
-                batchItemFailures.push({ itemIdentifier: record.messageId })
+                console.error(`Failed to process message: ${error}`);
+                batchItemFailures.push({ itemIdentifier: record.messageId });
             }
         }
 
-        return { batchItemFailures }
+        return { batchItemFailures };
     }
 
-    await processMessage(event, context)
-}
+    await processMessage(event, context);
+};
 
 const processMessage = async (event, context) => {
-    console.debug(event)
+    console.debug(event);
     if (!event.source) {
-        throw new Error("Event source property is missing")
+        throw new Error("Event source property is missing");
     }
 
-    const invokedArn = parseLambdaFunctionArn(context.invokedFunctionArn)
-    const collectorId = `arn:aws:lambda:${invokedArn.region}:${invokedArn.accountId}:function:${invokedArn.functionName}`
-    console.info(`Collector ${collectorId} starting collection`)
+    const invokedArn = parseLambdaFunctionArn(context.invokedFunctionArn);
+    const collectorId = `arn:aws:lambda:${invokedArn.region}:${invokedArn.accountId}:function:${invokedArn.functionName}`;
+    console.info(`Collector ${collectorId} starting collection`);
 
     switch (event.source.toLowerCase()) {
         case "collector.ec2":
-            await generateAndSendEc2Resources(collectorId, event.region, event.account, event.resources)
-            break
+            await generateAndSendEc2Resources(collectorId, event.region, event.account, event.resources);
+            break;
         case "collector.lambda":
-            await generateAndSendLambdaResources(collectorId, event.region, event.account, event.resources)
-            break
+            await generateAndSendLambdaResources(collectorId, event.region, event.account, event.resources);
+            break;
         case "aws.ec2":
-            await generateAndSendEc2Resources(collectorId, invokedArn.region, invokedArn.accountId, event.detail.responseElements.instancesSet.items)
-            break
+            await generateAndSendEc2Resources(collectorId, invokedArn.region, invokedArn.accountId, event.detail.responseElements.instancesSet.items);
+            break;
         case "aws.lambda":
-            await generateAndSendLambdaResources(collectorId, invokedArn.region, invokedArn.accountId, [event.detail.responseElements])
-            break
+            await generateAndSendLambdaResources(collectorId, invokedArn.region, invokedArn.accountId, [event.detail.responseElements]);
+            break;
         default:
-            throw new Error(`Unsupported event type: ${event.type}`)
+            throw new Error(`Unsupported event type: ${event.type}`);
     }
 
-    console.info("Collection done")
-}
+    console.info("Collection done");
+};
 
 const generateAndSendLambdaResources = async (collectorId, region, accountId, resources) => {
-    console.info(`Generating Lambda resources from ${region}`)
-    const lambdaResources = await generateLambdaResources(region, accountId, resources)
-    console.info("Sending Lambda resources to coralogix")
-    await sendToCoralogix({ collectorId, resources: lambdaResources })
-    console.info("Sent Lambda resources to coralogix")
-}
+    console.info(`Generating Lambda resources from ${region}`);
+    const lambdaResources = await generateLambdaResources(region, accountId, resources);
+    console.info("Sending Lambda resources to coralogix");
+    await sendToCoralogix({ collectorId, resources: lambdaResources });
+    console.info("Sent Lambda resources to coralogix");
+};
 
 const generateAndSendEc2Resources = async (collectorId, region, accountId, resources) => {
-    console.info(`Generating EC2 resources from ${region}`)
-    const ec2Resources = await generateEc2Resources(region, accountId, resources)
-    console.info("Sending EC2 resources to coralogix")
-    await sendToCoralogix({ collectorId, resources: ec2Resources })
-    console.info("Sent EC2 resources to coralogix")
-}
+    console.info(`Generating EC2 resources from ${region}`);
+    const ec2Resources = await generateEc2Resources(region, accountId, resources);
+    console.info("Sending EC2 resources to coralogix");
+    await sendToCoralogix({ collectorId, resources: ec2Resources });
+    console.info("Sent EC2 resources to coralogix");
+};

--- a/src/resource-metadata-sqs/generator/index.js
+++ b/src/resource-metadata-sqs/generator/index.js
@@ -53,16 +53,16 @@ const processMessage = async (event, context) => {
 
     switch (event.source.toLowerCase()) {
         case "collector.ec2":
-            await generateAndSendEc2Resources(collectorId, invokedArn.region, invokedArn.accountId, event.resources)
+            await generateAndSendEc2Resources(collectorId, event.region, invokedArn.accountId, event.resources)
             break
         case "collector.lambda":
-            await generateAndSendLambdaResources(collectorId, event.resources)
+            await generateAndSendLambdaResources(collectorId, event.region, event.resources)
             break
         case "aws.ec2":
             await generateAndSendEc2Resources(collectorId, invokedArn.region, invokedArn.accountId, event.detail.responseElements.instancesSet.items)
             break
         case "aws.lambda":
-            await generateAndSendLambdaResources(collectorId, [event.detail.responseElements])
+            await generateAndSendLambdaResources(collectorId, invokedArn.region, [event.detail.responseElements])
             break
         default:
             throw new Error(`Unsupported event type: ${event.type}`)
@@ -71,16 +71,16 @@ const processMessage = async (event, context) => {
     console.info("Collection done")
 }
 
-const generateAndSendLambdaResources = async (collectorId, resources) => {
-    console.info("Generating Lambda resources")
-    const lambdaResources = await generateLambdaResources(resources)
+const generateAndSendLambdaResources = async (collectorId, region, resources) => {
+    console.info(`Generating Lambda resources from ${region}`)
+    const lambdaResources = await generateLambdaResources(region, resources)
     console.info("Sending Lambda resources to coralogix")
     await sendToCoralogix({ collectorId, resources: lambdaResources })
     console.info("Sent Lambda resources to coralogix")
 }
 
 const generateAndSendEc2Resources = async (collectorId, region, accountId, resources) => {
-    console.info("Generating EC2 resources")
+    console.info(`Generating EC2 resources from ${region}`)
     const ec2Resources = await generateEc2Resources(region, accountId, resources)
     console.info("Sending EC2 resources to coralogix")
     await sendToCoralogix({ collectorId, resources: ec2Resources })

--- a/src/resource-metadata-sqs/generator/lambda.js
+++ b/src/resource-metadata-sqs/generator/lambda.js
@@ -1,18 +1,18 @@
-import assert from 'assert'
-import { LambdaClient, GetFunctionCommand, ListAliasesCommand, GetPolicyCommand, ListVersionsByFunctionCommand, ListEventSourceMappingsCommand } from '@aws-sdk/client-lambda'
+import assert from 'assert';
+import { LambdaClient, GetFunctionCommand, ListAliasesCommand, GetPolicyCommand, ListVersionsByFunctionCommand, ListEventSourceMappingsCommand } from '@aws-sdk/client-lambda';
 import { STSClient, AssumeRoleCommand, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
-import { schemaUrl, extractArchitecture, intAttr, stringAttr, traverse, flatTraverse } from './common.js'
+import { schemaUrl, extractArchitecture, intAttr, stringAttr, traverse, flatTraverse } from './common.js';
 
 const validateAndExtractConfiguration = () => {
-    assert(process.env.LATEST_VERSIONS_PER_FUNCTION, "LATEST_VERSIONS_PER_FUNCTION env var missing!")
-    const latestVersionsPerFunction = parseInt(process.env.LATEST_VERSIONS_PER_FUNCTION, 10)
-    assert(process.env.RESOURCE_TTL_MINUTES, "RESOURCE_TTL_MINUTES env var missing!")
-    const resourceTtlMinutes = parseInt(process.env.RESOURCE_TTL_MINUTES, 10)
-    assert(process.env.COLLECT_ALIASES, "COLLECT_ALIASES env var missing!")
-    const collectAliases = String(process.env.COLLECT_ALIASES).toLowerCase() === "true"
+    assert(process.env.LATEST_VERSIONS_PER_FUNCTION, "LATEST_VERSIONS_PER_FUNCTION env var missing!");
+    const latestVersionsPerFunction = parseInt(process.env.LATEST_VERSIONS_PER_FUNCTION, 10);
+    assert(process.env.RESOURCE_TTL_MINUTES, "RESOURCE_TTL_MINUTES env var missing!");
+    const resourceTtlMinutes = parseInt(process.env.RESOURCE_TTL_MINUTES, 10);
+    assert(process.env.COLLECT_ALIASES, "COLLECT_ALIASES env var missing!");
+    const collectAliases = String(process.env.COLLECT_ALIASES).toLowerCase() === "true";
     const roleArns = process.env.CROSSACCOUNT_IAM_ROLE_ARNS ? process.env.CROSSACCOUNT_IAM_ROLE_ARNS.split(',') : [];
     return { latestVersionsPerFunction, resourceTtlMinutes, collectAliases, roleArns };
-}
+};
 const { latestVersionsPerFunction, resourceTtlMinutes, collectAliases, roleArns } = validateAndExtractConfiguration();
 
 // Function to assume a role using AWS SDK v3
@@ -64,94 +64,94 @@ export const generateLambdaResources = async (region, accountId, functions) => {
         lambdaClient = new LambdaClient({ region, credentials });
     }
 
-    console.info("Generating function details")
-    const { functionResources, aliasResources, versionsToCollect } = await generateFunctionAndAliasResources(lambdaClient, functions)
+    console.info("Generating function details");
+    const { functionResources, aliasResources, versionsToCollect } = await generateFunctionAndAliasResources(lambdaClient, functions);
 
-    console.info("Generating function version details")
-    const functionVersionResources = await generateFunctionVersionResources(lambdaClient, versionsToCollect)
+    console.info("Generating function version details");
+    const functionVersionResources = await generateFunctionVersionResources(lambdaClient, versionsToCollect);
 
-    const resources = [...functionResources, ...functionVersionResources, ...aliasResources]
+    const resources = [...functionResources, ...functionVersionResources, ...aliasResources];
 
-    console.info(`Generated ${functionResources.length} functions, ${functionVersionResources.length} function versions and ${aliasResources.length} aliases`)
+    console.info(`Generated ${functionResources.length} functions, ${functionVersionResources.length} function versions and ${aliasResources.length} aliases`);
 
-    return resources
-}
+    return resources;
+};
 
 const generateFunctionAndAliasResources = async (lambdaClient, listOfFunctions) => {
     const results = await flatTraverse(listOfFunctions, async (lambdaFunctionVersionLatest, index) => {
         // Handle both Lambda API and EventBridge property casing
-        const functionName = lambdaFunctionVersionLatest.functionName ?? lambdaFunctionVersionLatest.FunctionName
+        const functionName = lambdaFunctionVersionLatest.functionName ?? lambdaFunctionVersionLatest.FunctionName;
         try {
-            const lambdaFunction = await lambdaClient.send(new GetFunctionCommand({ FunctionName: functionName }))
-            const functionResource = makeLambdaFunctionResource(lambdaFunction)
+            const lambdaFunction = await lambdaClient.send(new GetFunctionCommand({ FunctionName: functionName }));
+            const functionResource = makeLambdaFunctionResource(lambdaFunction);
 
             const aliases = collectAliases
                 ? (await lambdaClient.send(new ListAliasesCommand({ FunctionName: functionName })))?.Aliases
-                : []
-            const aliasResources = aliases.map(alias => makeAliasResource(functionName, alias))
+                : [];
+            const aliasResources = aliases.map(alias => makeAliasResource(functionName, alias));
 
             const versions = latestVersionsPerFunction > 0
                 ? (await lambdaClient.send(new ListVersionsByFunctionCommand({ FunctionName: functionName }))).Versions
-                : [lambdaFunctionVersionLatest]
+                : [lambdaFunctionVersionLatest];
 
             const versionsToCollect = versions.filter((version, index) => {
-                const versionNumber = version.version ?? version.Version
+                const versionNumber = version.version ?? version.Version;
                 return (index <= latestVersionsPerFunction)
-                    || (aliases.some(alias => versionNumber === alias.FunctionVersion))
-            })
+                    || (aliases.some(alias => versionNumber === alias.FunctionVersion));
+            });
 
-            console.debug(`Function (${index + 1}/${listOfFunctions.length}): ${JSON.stringify(functionResource)}`)
-            aliasResources.forEach(a => console.debug(`Alias: ${JSON.stringify(a)}`))
+            console.debug(`Function (${index + 1}/${listOfFunctions.length}): ${JSON.stringify(functionResource)}`);
+            aliasResources.forEach(a => console.debug(`Alias: ${JSON.stringify(a)}`));
 
-            return { functionResource, aliasResources, versionsToCollect }
+            return { functionResource, aliasResources, versionsToCollect };
         } catch (error) {
-            console.warn(`Failed to generate metadata of ${functionName}: `, error.stack)
+            console.warn(`Failed to generate metadata of ${functionName}: `, error.stack);
         }
-    })
+    });
 
     if (listOfFunctions.length > 0 && results.length == 0) {
-        console.error("Failed to generate metadata of any lambda function.")
-        throw "Failed to generate metadata of any lambda function."
+        console.error("Failed to generate metadata of any lambda function.");
+        throw "Failed to generate metadata of any lambda function.";
     }
 
     return {
         functionResources: results.map(x => x.functionResource),
         aliasResources: results.flatMap(x => x.aliasResources),
         versionsToCollect: results.flatMap(x => x.versionsToCollect),
-    }
-}
+    };
+};
 
 const generateFunctionVersionResources = async (lambdaClient, versionsToCollect) =>
     await traverse(versionsToCollect, async (lambdaFunctionVersion, index) => {
-        const version = lambdaFunctionVersion.version ?? lambdaFunctionVersion.Version
-        const functionName = lambdaFunctionVersion.functionName ?? lambdaFunctionVersion.FunctionName
+        const version = lambdaFunctionVersion.version ?? lambdaFunctionVersion.Version;
+        const functionName = lambdaFunctionVersion.functionName ?? lambdaFunctionVersion.FunctionName;
         const functionNameForRequests = version === "$LATEST"
             ? functionName
-            : `${functionName}:${version}`
+            : `${functionName}:${version}`;
 
-        let eventSourceMappings = null
+        let eventSourceMappings = null;
         try {
-            eventSourceMappings = await lambdaClient.send(new ListEventSourceMappingsCommand({ FunctionName: functionNameForRequests }))
+            eventSourceMappings = await lambdaClient.send(new ListEventSourceMappingsCommand({ FunctionName: functionNameForRequests }));
         } catch (error) {
-            console.warn(`Failed to generate event source mappings of ${functionNameForRequests}: `, error.stack)
+            console.warn(`Failed to generate event source mappings of ${functionNameForRequests}: `, error.stack);
         }
-        let maybePolicy = null
+        let maybePolicy = null;
         try {
-            maybePolicy = await lambdaClient.send(new GetPolicyCommand({ FunctionName: functionNameForRequests }))
+            maybePolicy = await lambdaClient.send(new GetPolicyCommand({ FunctionName: functionNameForRequests }));
         } catch (e) {
             // GetPolicyCommand results in an error if the lambda has no policy defined.
             // Ignore this error, and proceed with maybePolicy = null
         }
-        const functionVersionResource = makeLambdaFunctionVersionResource(lambdaFunctionVersion, eventSourceMappings, maybePolicy)
+        const functionVersionResource = makeLambdaFunctionVersionResource(lambdaFunctionVersion, eventSourceMappings, maybePolicy);
 
-        console.debug(`FunctionVersion (${index + 1}/${versionsToCollect.length}): ${JSON.stringify(functionVersionResource)}`)
+        console.debug(`FunctionVersion (${index + 1}/${versionsToCollect.length}): ${JSON.stringify(functionVersionResource)}`);
 
-        return functionVersionResource
-    })
+        return functionVersionResource;
+    });
 
 const makeLambdaFunctionResource = (f) => {
-    const functionArn = f.Configuration.functionArn ?? f.Configuration.FunctionArn
-    const arn = parseLambdaFunctionArn(functionArn)
+    const functionArn = f.Configuration.functionArn ?? f.Configuration.FunctionArn;
+    const arn = parseLambdaFunctionArn(functionArn);
 
     const attributes = [
         stringAttr("cloud.provider", "aws"),
@@ -161,13 +161,13 @@ const makeLambdaFunctionResource = (f) => {
         stringAttr("cloud.resource_id", functionArn),
         stringAttr("faas.name", arn.functionName),
         stringAttr("lambda.last_update_status", f.Configuration.lastUpdateStatus ?? f.Configuration.LastUpdateStatus),
-    ]
+    ];
 
-    attributes.push(...convertFunctionTagsToAttributes(f.Tags))
+    attributes.push(...convertFunctionTagsToAttributes(f.Tags));
 
-    const reservedConcurrency = f.Concurrency?.ReservedConcurrentExecutions || f.concurrency?.reservedConcurrentExecutions
+    const reservedConcurrency = f.Concurrency?.ReservedConcurrentExecutions || f.concurrency?.reservedConcurrentExecutions;
     if (reservedConcurrency) {
-        attributes.push(intAttr("lambda.reserved_concurrency", reservedConcurrency))
+        attributes.push(intAttr("lambda.reserved_concurrency", reservedConcurrency));
     }
 
     return {
@@ -179,25 +179,25 @@ const makeLambdaFunctionResource = (f) => {
             seconds: resourceTtlMinutes * 60,
             nanos: 0,
         },
-    }
-}
+    };
+};
 
 const convertFunctionTagsToAttributes = tags => {
     if (!tags) {
-        return []
+        return [];
     }
     return Object.entries(tags).map(([key, value]) => stringAttr(`cloud.tag.${key}`, value));
-}
+};
 
 const makeLambdaFunctionVersionResource = (fv, eventSourceMappings, maybePolicy) => {
-    const originalArn = fv.functionArn ?? fv.FunctionArn
-    const arn = parseLambdaFunctionVersionArn(originalArn)
-    const functionArn = `arn:aws:lambda:${arn.region}:${arn.accountId}:function:${arn.functionName}`
-    const version = fv.version ?? fv.Version
-    const functionVersionArn = `arn:aws:lambda:${arn.region}:${arn.accountId}:function:${arn.functionName}:${version}`
-    const resourceId = functionVersionArn
-    const architectures = fv.architectures ?? fv.Architectures
-    const arch = extractArchitecture(architectures)
+    const originalArn = fv.functionArn ?? fv.FunctionArn;
+    const arn = parseLambdaFunctionVersionArn(originalArn);
+    const functionArn = `arn:aws:lambda:${arn.region}:${arn.accountId}:function:${arn.functionName}`;
+    const version = fv.version ?? fv.Version;
+    const functionVersionArn = `arn:aws:lambda:${arn.region}:${arn.accountId}:function:${arn.functionName}:${version}`;
+    const resourceId = functionVersionArn;
+    const architectures = fv.architectures ?? fv.Architectures;
+    const arch = extractArchitecture(architectures);
 
     const attributes = [
         stringAttr("cloud.provider", "aws"),
@@ -216,24 +216,24 @@ const makeLambdaFunctionVersionResource = (fv, eventSourceMappings, maybePolicy)
         intAttr("lambda.timeout", fv.timeout ?? fv.Timeout),
         stringAttr("lambda.iam_role", fv.role ?? fv.Role),
         stringAttr("lambda.function_arn", functionArn),
-    ]
+    ];
 
-    const layers = fv.layers ?? fv.Layers
+    const layers = fv.layers ?? fv.Layers;
     if (layers) {
         layers.forEach((layer, index) => {
-            attributes.push(stringAttr(`lambda.layer.${index}.arn`, layer.arn ?? layer.Arn))
-            attributes.push(stringAttr(`lambda.layer.${index}.code_size`, layer.codeSize ?? layer.CodeSize))
-        })
+            attributes.push(stringAttr(`lambda.layer.${index}.arn`, layer.arn ?? layer.Arn));
+            attributes.push(stringAttr(`lambda.layer.${index}.code_size`, layer.codeSize ?? layer.CodeSize));
+        });
     }
 
     if (eventSourceMappings && eventSourceMappings.EventSourceMappings) {
         eventSourceMappings.EventSourceMappings.forEach((eventSource, index) => {
-            attributes.push(stringAttr(`lambda.event_source.${index}.arn`, eventSource.eventSourceArn ?? eventSource.EventSourceArn))
-        })
+            attributes.push(stringAttr(`lambda.event_source.${index}.arn`, eventSource.eventSourceArn ?? eventSource.EventSourceArn));
+        });
     }
 
     if (maybePolicy) {
-        attributes.push(stringAttr("lambda.policy", maybePolicy.Policy))
+        attributes.push(stringAttr("lambda.policy", maybePolicy.Policy));
     }
 
     return {
@@ -245,17 +245,17 @@ const makeLambdaFunctionVersionResource = (fv, eventSourceMappings, maybePolicy)
             seconds: resourceTtlMinutes * 60,
             nanos: 0,
         },
-    }
-}
+    };
+};
 
 const makeAliasResource = (functionName, alias) => {
-    const resourceId = alias.AliasArn
+    const resourceId = alias.AliasArn;
     const attributes = [
         stringAttr("cloud.resource_id", resourceId),
         stringAttr("faas.name", functionName),
         stringAttr("lambda.alias.name", alias.Name),
         stringAttr("faas.version", alias.FunctionVersion),
-    ]
+    ];
     return {
         resourceId: resourceId,
         resourceType: "aws:lambda:function-alias",
@@ -265,8 +265,8 @@ const makeAliasResource = (functionName, alias) => {
             seconds: resourceTtlMinutes * 60,
             nanos: 0,
         },
-    }
-}
+    };
+};
 
 export const parseLambdaFunctionArn = (lambdaFunctionArn) => {
     const arn = lambdaFunctionArn.split(":");
@@ -274,8 +274,8 @@ export const parseLambdaFunctionArn = (lambdaFunctionArn) => {
         region: arn[3],
         accountId: arn[4],
         functionName: arn[6],
-    }
-}
+    };
+};
 
 const parseLambdaFunctionVersionArn = (lambdaFunctionVersionArn) => {
     const arn = lambdaFunctionVersionArn.split(":");
@@ -284,5 +284,5 @@ const parseLambdaFunctionVersionArn = (lambdaFunctionVersionArn) => {
         accountId: arn[4],
         functionName: arn[6],
         functionVersion: arn[7],
-    }
-}
+    };
+};

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/client-ec2": "^3.502.0",
     "@aws-sdk/client-lambda": "^3.502.0",
     "@aws-sdk/client-resource-groups-tagging-api": "^3.502.0",
+    "@aws-sdk/client-sts": "^3.502.0",
     "@grpc/grpc-js": "^1.10.9",
     "@grpc/proto-loader": "^0.7.10"
   },

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-generator",
   "title": "AWS Resource Generator Lambda function for Coralogix",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "AWS Lambda function to generate AWS EC2/Lambda resources for Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/generator/testEvent.json
+++ b/src/resource-metadata-sqs/generator/testEvent.json
@@ -1,5 +1,7 @@
 {
     "source": "collector.lambda",
+    "region": "eu-north-1",
+    "account": "123456789012",
     "resources": [
         {
             "Description": "",

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -33,6 +33,7 @@ Metadata:
         Parameters:
           - Schedule
           - SourceRegions
+          - CrossAccountIAMRoleArns
           - ResourceTtlMinutes
           - LatestVersionsPerFunction
           - CollectAliases
@@ -66,6 +67,10 @@ Metadata:
         default: Api Key
       EventMode:
         default: Event Mode
+      CrossAccountIAMRoleArns:
+        default: Cross Account IAM Role ARNs
+      SourceRegions:
+        default: Source AWS Regions
       Schedule:
         default: Schedule
       LatestVersionsPerFunction:
@@ -121,6 +126,10 @@ Parameters:
   SourceRegions:
     Type: String
     Description: The regions to collect metadata from, separated by commas (e.g. eu-north-1,eu-west-1,us-east-1). Leave empty if you want to collect metadata from the current region only.
+    Default: ""
+  CrossAccountIAMRoleArns:
+    Type: String
+    Description: The IAM role ARNs to collect metadata from, separated by commas (e.g. arn:aws:iam::123456789012:role/CrossAccountRole,arn:aws:iam::123456789012:role/AnotherCrossAccountRole). Leave empty if you want to collect metadata from the current account only.
     Default: ""
   EventMode:
     Type: String
@@ -283,7 +292,8 @@ Conditions:
     - !Equals [!Ref EventMode, EnabledCreateTrail]
   ShouldCreateCloudTrail: !Equals [!Ref EventMode, EnabledCreateTrail]
   UseExistingCloudTrail: !Equals [!Ref EventMode, EnabledWithExistingTrail]
-  ShouldCreateRegionsEnv: !Not [!Equals [!Ref SourceRegions, ""]]
+  MultiRegionEnabled: !Not [!Equals [!Ref SourceRegions, ""]]
+  MultiAccountEnabled: !Not [!Equals [!Ref CrossAccountIAMRoleArns, ""]]
 Resources:
   MetadataQueue:
     Type: AWS::SQS::Queue
@@ -313,8 +323,12 @@ Resources:
           LAMBDA_FUNCTION_TAG_FILTERS:
             Ref: LambdaFunctionTagFilters
           REGIONS: !If
-            - ShouldCreateRegionsEnv
+            - MultiRegionEnabled
             - Ref: SourceRegions
+            - !Ref 'AWS::NoValue'
+          CROSSACCOUNT_IAM_ROLE_ARNS: !If
+            - MultiAccountEnabled
+            - Ref: CrossAccountIAMRoleArns
             - !Ref 'AWS::NoValue'
           AWS_RETRY_MODE: adaptive
           AWS_MAX_ATTEMPTS: 10
@@ -373,6 +387,15 @@ Resources:
               Action:
                 - sqs:SendMessage
               Resource: !GetAtt MetadataQueue.Arn
+        - !If
+          - MultiAccountEnabled
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: AssumeCrossAccountRoles
+                Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Split [",", !Ref CrossAccountIAMRoleArns]
+          - !Ref 'AWS::NoValue'
 
   CollectorLambdaFunctionNotificationSubscription:
     Type: AWS::SNS::Subscription
@@ -405,6 +428,10 @@ Resources:
             Ref: CollectAliases
           RESOURCE_TTL_MINUTES:
             Ref: ResourceTtlMinutes
+          CROSSACCOUNT_IAM_ROLE_ARNS: !If
+            - MultiAccountEnabled
+            - Ref: CrossAccountIAMRoleArns
+            - !Ref 'AWS::NoValue'
           CORALOGIX_METADATA_URL: !If
             - IsRegionCustomUrlEmpty
             - !Sub  'ingress.${CustomDomain}:443'
@@ -453,6 +480,15 @@ Resources:
                 - sqs:DeleteMessage
                 - sqs:GetQueueAttributes
               Resource: !GetAtt MetadataQueue.Arn
+        - !If
+          - MultiAccountEnabled
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: AssumeCrossAccountRoles
+                Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Split [",", !Ref CrossAccountIAMRoleArns]
+          - !Ref 'AWS::NoValue'
 
   GeneratorLambdaFunctionSM:
     Condition: IsSMEnabled
@@ -486,6 +522,10 @@ Resources:
               - Prefix: ingress.
                 Domain: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, MetadataUrl]
                 Suffix: :443
+          CROSSACCOUNT_IAM_ROLE_ARNS: !If
+            - MultiAccountEnabled
+            - Ref: CrossAccountIAMRoleArns
+            - !Ref 'AWS::NoValue'
           AWS_LAMBDA_EXEC_WRAPPER: /opt/wrapper.sh
           AWS_RETRY_MODE: adaptive
           AWS_MAX_ATTEMPTS: 10
@@ -529,6 +569,15 @@ Resources:
                 - sqs:DeleteMessage
                 - sqs:GetQueueAttributes
               Resource: !GetAtt MetadataQueue.Arn
+        - !If
+          - MultiAccountEnabled
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: AssumeCrossAccountRoles
+                Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Split [",", !Ref CrossAccountIAMRoleArns]
+          - !Ref 'AWS::NoValue'
         - SecretsManagerReadWrite
 
   PrivateKeySecret:

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -14,7 +14,7 @@ Metadata:
       - metadata
       - sqs
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.1.4
+    SemanticVersion: 0.2.0
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -32,6 +32,7 @@ Metadata:
           default: Integration configuration
         Parameters:
           - Schedule
+          - SourceRegions
           - ResourceTtlMinutes
           - LatestVersionsPerFunction
           - CollectAliases
@@ -117,9 +118,13 @@ Parameters:
     Type: String
     Description: Your Coralogix Send Your Data - API Key or incase you use pre created secret (created in AWS secret manager) put here the name of the secret that contains the Coralogix send your data key
     NoEcho: true
+  SourceRegions:
+    Type: String
+    Description: The regions to collect metadata from, separated by commas (e.g. eu-north-1,eu-west-1,us-east-1). Leave empty if you want to collect metadata from the current region only.
+    Default: ""
   EventMode:
     Type: String
-    Description: Enable real-time processing of CloudTrail events via EventBridge [Disabled, EnabledWithExistingTrail, EnabledCreateTrail]
+    Description: Enable real-time processing of CloudTrail events via EventBridge [Disabled, EnabledWithExistingTrail, EnabledCreateTrail]. Note that it will be created in the current region only.
     AllowedValues:
       - Disabled
       - EnabledWithExistingTrail 
@@ -278,6 +283,7 @@ Conditions:
     - !Equals [!Ref EventMode, EnabledCreateTrail]
   ShouldCreateCloudTrail: !Equals [!Ref EventMode, EnabledCreateTrail]
   UseExistingCloudTrail: !Equals [!Ref EventMode, EnabledWithExistingTrail]
+  ShouldCreateRegionsEnv: !Not [!Equals [!Ref SourceRegions, ""]]
 Resources:
   MetadataQueue:
     Type: AWS::SQS::Queue
@@ -306,6 +312,10 @@ Resources:
             Ref: LambdaFunctionExcludeRegexFilter
           LAMBDA_FUNCTION_TAG_FILTERS:
             Ref: LambdaFunctionTagFilters
+          REGIONS: !If
+            - ShouldCreateRegionsEnv
+            - Ref: SourceRegions
+            - !Ref 'AWS::NoValue'
           AWS_RETRY_MODE: adaptive
           AWS_MAX_ATTEMPTS: 10
           IS_EC2_RESOURCE_TYPE_EXCLUDED: !If


### PR DESCRIPTION
# Description

Fixes CDS-1996. This will enable users to collect resource metadata (Lambda and EC2) from multiple regions and accounts using one function without the need to deploy the template to each region, from which the metadata needs to be collected.

Additionally, this will fix line endings in JS code that were always different in each file; now each line will end with a semicolon (`;`).

Not breaking change, allows updating with `0.1.x` without any extra user effort.

# How Has This Been Tested?

Run both code+CF template test on our env, using first 1 region and then 6 regions, then 2 accounts and 10 regions, ensured that:

1. I get the metadata from all regions listed
2. There is no visible performance downgrade, running this change.

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)