### PR TITLE
Fix issue with lamdba manager

### DIFF
--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## lambda-manager
 
+## 2.0.6  / 15-04-2025
+### 🧰 Bug fixes 🧰
+- Remove from the default value of RegexPattern the backslash.
+- Update the lambda code so it will be compatible with requests from Terraform.
+
 ## 2.0.5  / 17-02-2025
 ### 🧰 Bug fixes 🧰
 - Remove wildcard from the lambda permission policy.

--- a/src/lambda-manager/lambda_function.py
+++ b/src/lambda-manager/lambda_function.py
@@ -78,7 +78,7 @@ def lambda_handler(event, context):
         print(f"Failed with exception: {e}")
         status = cfnresponse.FAILED
     finally:
-        if "RequestType" in event:
+        if "RequestType" in event and "ResponseURL" in event:
             print("Sending response to custom resource")
             cfnresponse.send(
                 event,
@@ -87,6 +87,8 @@ def lambda_handler(event, context):
                 {},
                 event.get('PhysicalResourceId', context.aws_request_id)
             )
+        else:
+            print("Skipping cfnresponse.send — not a CloudFormation event")
 
 def list_log_groups_and_subscriptions(cloudwatch_logs, regex_pattern_list, logs_filter, destination_arn, filter_name, context,log_group_permission_prefix):
     '''Scan for all of the log groups in the region and add subscription to the log groups that match the regex pattern, this function will only run 1 time'''

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -16,7 +16,7 @@ Metadata:
       - cloudwatch
       - lambda
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 2.0.5
+    SemanticVersion: 2.0.6
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -61,7 +61,7 @@ Parameters:
   RegexPattern:
     Type: String
     Description: Comma-separated list of Loggroup name regex pattern
-    Default: \/aws\/lambda\/.*
+    Default: /aws/lambda/.*
   LogGroupPermissionPreFix:
     Type: String
     Description: instead creating one permission for each log group in the destination lambda, the code will take the prefix that you set in the parameter and create 1 permission for all of the log groups that match the prefix


### PR DESCRIPTION
# Description

- Remove from the default value of RegexPattern the backslash, as it's not compatible with serverless.
- Update the lambda code so it will be compatible with requests from Terraform

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)