### PR TITLE
fix issue with manager for non STANDARD log groups

### DIFF
--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## lambda-manager
 
+## 2.0.7  / 20-04-2025
+### 🧰 Bug fixes 🧰
+- Add a check if the log group is a standard log group, and if not, it will be excluded.
+
 ## 2.0.6  / 15-04-2025
 ### 🧰 Bug fixes 🧰
 - Remove from the default value of RegexPattern the backslash.

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -16,7 +16,7 @@ Metadata:
       - cloudwatch
       - lambda
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 2.0.6
+    SemanticVersion: 2.0.7
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description
The lambda will fail if it tries to subscribe to log groups of type `Infrequent Access`, as you can't add a subscription to this type of log groups, I have added a condition to the code to check the type of log group, and if its not standard, it will be excluded
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the versions in the changed module in the template index.js and package.json files.
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)