### PR TITLE
fix: add crossaccount.js to package.json files in resource-metadata-sqs

### DIFF
--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.3.1 / 05.05.2025
+* [Fix] Mention crossaccount.js in package.json to make it a part of the build
+
 ### 0.3.0 / 30.04.2025
 * [Feature] Cross-account collection has multiple options now: AWS Config and Static Account List
 * [Feature] Enable cross-account Eventbridge events reception by SQS queue

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-collector",
   "title": "AWS Resource Collector Lambda function for Coralogix",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AWS Lambda function to collect AWS EC2/Lambda resources for further processing",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",
@@ -45,6 +45,7 @@
     "ec2.js",
     "lambda.js",
     "sqs.js",
-    "index.js"
+    "index.js",
+    "crossaccount.js"
   ]
 }

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-generator",
   "title": "AWS Resource Generator Lambda function for Coralogix",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AWS Lambda function to generate AWS EC2/Lambda resources for Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",
@@ -46,6 +46,7 @@
     "coralogix.js",
     "ec2.js",
     "lambda.js",
+    "crossaccount.js",
     "proto/service.proto",
     "proto/opentelemetry/proto/common/v1/common.proto"
   ]


### PR DESCRIPTION
# Description

This will fix the incomplete release of `resource-metadata-sqs-0.3.0`, where the new module `crossaccount.js` is absent, because it wasn't declared in `package.json`. I failed to reproduce this issue running `sam package` locally, and found it out after I tested the UI Integration.

Adding files to `package.json` solves this problem.