### PR TITLE
fix: update node.js version to 22.x in resource-metadata

### DIFF
--- a/src/resource-metadata/CHANGELOG.md
+++ b/src/resource-metadata/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata
 
+### 1.2.12 / 04.12.2025
+* [Update] Update Node.js version to 22.x
+
 ### 1.2.11 / 15.10.2024
 * [Fix] Fix typo in the conditioning to exclude ec2/lambdas resources.
 

--- a/src/resource-metadata/package.json
+++ b/src/resource-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-tags",
   "title": "AWS Resource Tags Lambda function for Coralogix",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "AWS Lambda function to send AWS resource tags to Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata/template.yaml
+++ b/src/resource-metadata/template.yaml
@@ -13,7 +13,7 @@ Metadata:
       - coralogix
       - metadata
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.2.11
+    SemanticVersion: 1.2.12
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/src/resource-metadata/template.yaml
+++ b/src/resource-metadata/template.yaml
@@ -248,7 +248,7 @@ Resources:
       Description: Send resource metadata to Coralogix.
       CodeUri: .
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Architectures:
         - Ref: FunctionArchitecture
       MemorySize:
@@ -342,7 +342,7 @@ Resources:
       Layers:
         - Ref: LayerARN
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Architectures:
         - Ref: FunctionArchitecture
       MemorySize:


### PR DESCRIPTION
# Description

Fixes CDS-2570 by updating Node.js version to 22.x in `resource-metadata` module

# How Has This Been Tested?

Run the function with updated Node.js version to make sure it runs as expected and provides a desired output.

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)