### PR TITLE
feat: add the option to query AWS Config cross-account

### DIFF
--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata-sqs
 
+### 0.3.2 / 20.02.2025
+* [Feature] Assume cross-account IAM role when querying AWS Config aggregator in a different account (`ConfigCrossAccountRole` parameter)
+
 ### 0.3.1 / 05.05.2025
 * [Fix] Mention crossaccount.js in package.json to make it a part of the build
 

--- a/src/resource-metadata-sqs/README.md
+++ b/src/resource-metadata-sqs/README.md
@@ -28,7 +28,7 @@ To enable this feature, you need to specify the `CrossAccountMode` parameter (`D
 There are two options to collect metadata across accounts:
 
 1. IAM Cross-account roles (`StaticIAM`): loops over account IDs (`AccountIds`), assuming IAM role in each account. IAM role should have the same name in each account (`CrossAccountIAMRoleName`).
-2. AWS Config Resource Aggregator (`Config`): runs a Query on AWS Config Aggregator (`ConfigAggregatorName`) deployed in the account where the `resource-metadata` is running. It also requires IAM cross-account roles setup.
+2. AWS Config Resource Aggregator (`Config`): runs a Query on AWS Config Aggregator (`ConfigAggregatorName`). If the aggregator is in a different account, set `ConfigCrossAccountRole` to the IAM role ARN in that account; the collector will assume it when querying Config. It also requires IAM cross-account roles setup for the generator.
 
 There are many other ways to collect the metadata about Lambda functions and EC2 instances from different accounts. See [the cross-account solutions doc](./collector/CROSSACCOUNT_SOLUTIONS.md) for more details. The rest of those options can be implemented on demand.
 
@@ -215,6 +215,7 @@ EC2 only:
 | SourceRegions | The regions to collect metadata from, separated by commas (e.g. eu-north-1,eu-west-1,us-east-1). Leave empty if you want to collect metadata from the current region only. | | |
 | CrossAccountMode | The mode to collect metadata from multiple accounts[Disabled, StaticIAM, Config]. Leave Disabled if you want to collect metadata from the current account only. | Disabled | |
 | ConfigAggregatorName | The name of the AWS Config Aggregator to run the query. Used if `CrossAccountMode` is set to `Config`. | | |
+| ConfigCrossAccountRole | IAM role ARN in the account where the AWS Config aggregator lives. If set, the collector will assume this role when querying Config (use when the aggregator is in a different account). | | |
 | AccountIds | The list of account IDs, separated by comma. Used if `CrossAccountMode` is set to `StaticIAM`. | Disabled | |
 | CrossAccountIAMRoleName | The name of the IAM cross-account roles set in each source account. Used if `CrossAccountMode` is not `Disabled`. | Disabled | |
 

--- a/src/resource-metadata-sqs/collector/crossaccount.js
+++ b/src/resource-metadata-sqs/collector/crossaccount.js
@@ -47,7 +47,13 @@ export const getAccountId = async (clientConfig = {}) => {
 export const collectResourcesViaConfig = async (configAggregatorName, resourceType) => {
     console.info("Collecting Lambda resources via AWS Config");
     try {
-        const configClient = new ConfigServiceClient({ region: process.env.AWS_REGION });
+        const configRoleArn = process.env.CROSSACCOUNT_CONFIG_ASSUME_ROLE;
+        const clientConfig = { region: process.env.AWS_REGION };
+        if (configRoleArn) {
+            const credentials = await assumeRole(configRoleArn);
+            clientConfig.credentials = credentials;
+        }
+        const configClient = new ConfigServiceClient(clientConfig);
         const batchSize = 50;
 
         const baseQuery = `SELECT arn, resourceId, awsRegion, accountId WHERE resourceType = '${resourceType}'`;

--- a/src/resource-metadata-sqs/collector/package.json
+++ b/src/resource-metadata-sqs/collector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-collector",
   "title": "AWS Resource Collector Lambda function for Coralogix",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AWS Lambda function to collect AWS EC2/Lambda resources for further processing",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/generator/package.json
+++ b/src/resource-metadata-sqs/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-resource-generator",
   "title": "AWS Resource Generator Lambda function for Coralogix",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AWS Lambda function to generate AWS EC2/Lambda resources for Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -14,7 +14,7 @@ Metadata:
       - metadata
       - sqs
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.3.0
+    SemanticVersion: 0.3.2
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -35,6 +35,7 @@ Metadata:
           - SourceRegions
           - CrossAccountMode
           - ConfigAggregatorName
+          - ConfigCrossAccountRole
           - AccountIds
           - CrossAccountIAMRoleName
       - Label:
@@ -79,6 +80,8 @@ Metadata:
         default: Cross Account Mode
       ConfigAggregatorName:
         default: Config Aggregator Name
+      ConfigCrossAccountRole:
+        default: Config Cross-Account Role ARN
       OrganizationId:
         default: AWS Organization ID
       SourceRegions:
@@ -156,6 +159,10 @@ Parameters:
   ConfigAggregatorName:
     Type: String
     Description: The name of the AWS Config aggregator to collect metadata from. Leave empty if you want to collect metadata from the current account only.
+    Default: ""
+  ConfigCrossAccountRole:
+    Type: String
+    Description: IAM role ARN in the account where AWS Config aggregator lives. If set, the collector will assume this role when querying Config (use when aggregator is in a different account).
     Default: ""
   AccountIds:
     Type: String
@@ -344,6 +351,7 @@ Conditions:
   CrossAccountEnabled: !Not [!Equals [!Ref CrossAccountMode, Disabled]]
   CrossAccountIamMode: !Equals [!Ref CrossAccountMode, StaticIAM]
   CrossAccountConfigMode: !Equals [!Ref CrossAccountMode, Config]
+  ConfigCrossAccountRoleSet: !Not [!Equals [!Ref ConfigCrossAccountRole, ""]]
   CrossAccountHasOrgId: !Not [!Equals [!Ref OrganizationId, ""]]
 
 Resources:
@@ -409,6 +417,10 @@ Resources:
           CROSSACCOUNT_CONFIG_AGGREGATOR: !If
             - CrossAccountConfigMode
             - Ref: ConfigAggregatorName
+            - !Ref 'AWS::NoValue'
+          CROSSACCOUNT_CONFIG_ASSUME_ROLE: !If
+            - ConfigCrossAccountRoleSet
+            - Ref: ConfigCrossAccountRole
             - !Ref 'AWS::NoValue'
           AWS_RETRY_MODE: adaptive
           AWS_MAX_ATTEMPTS: 10
@@ -484,6 +496,15 @@ Resources:
                 Effect: Allow
                 Action: config:SelectAggregateResourceConfig
                 Resource: "*"
+          - !Ref 'AWS::NoValue'
+        - !If
+          - ConfigCrossAccountRoleSet
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: AssumeConfigCrossAccountRole
+                Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Ref ConfigCrossAccountRole
           - !Ref 'AWS::NoValue'
 
   CollectorLambdaFunctionNotificationSubscription:


### PR DESCRIPTION
# Description

Fixes CDS-2750 by introducing the option to query AWS Config Aggregator cross-account by using `ConfigCrossAccountRole` CF parameter aka. `CROSSACCOUNT_CONFIG_ASSUME_ROLE`.

# How Has This Been Tested?

Tested in my local setup.

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)