### PR TITLE
ci: trigger documentation sync on resource-metadata-sqs README changes

### DIFF
--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -1,0 +1,22 @@
+name: Trigger Documentation Sync
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/resource-metadata-sqs/README.md'
+
+jobs:
+  trigger_action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger ci action in documentation repo
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/coralogix/documentation/dispatches \
+               -d '{
+                     "event_type": "trigger-deploy"
+                   }'

--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'src/resource-metadata-sqs/README.md'
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   trigger_action:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The Coralogix docs portal syncs `src/resource-metadata-sqs/README.md` into its external content (rendered at `/docs/integrations/aws/aws-resource-metadata-collection/`), but this repo had no workflow to notify the docs portal when that README changed. Doc edits required a manual deploy.
- Add `Trigger Documentation Sync` workflow that fires a `trigger-deploy` repository_dispatch on `coralogix/documentation` when the synced README is updated on `master`, following the canonical pattern used in `terraform-coralogix-aws`, `coralogix-aws-shipper`, and `telemetry-shippers`.

Found while auditing all `coralogix/documentation` source repos for trigger coverage.

## Prereqs
- `secrets.GH_TOKEN` needs `repo` scope to dispatch on `coralogix/documentation`. Confirm with infra before merging.

## Test plan
- [ ] After merge, push a trivial change to `src/resource-metadata-sqs/README.md` on `master` and verify the workflow runs and the docs deploy is triggered.
- [ ] Trigger via the **Run workflow** button (`workflow_dispatch`) and confirm the same.
- [ ] Push a change to an unrelated file on `master` and confirm the workflow does **not** fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)