### PR TITLE
docs: add TW as blocking reviewer for synced documentation files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Technical writers own documentation
+src/resource-metadata-sqs/README.md @coralogix/team-technical-writers


### PR DESCRIPTION
## Why

`src/resource-metadata-sqs/README.md` is synced automatically into the Coralogix documentation portal via `external_repos.json`. Any change to this file triggers an immediate docs redeploy.

This PR creates a `CODEOWNERS` file so that no change to this synced file can merge without sign-off from the Technical Writing team.