### PR TITLE
security: close helper alerts and easy code scanning findings

### DIFF
--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -1,4 +1,9 @@
 name: Changelog
+
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]

--- a/.github/workflows/Synchronizing.yml
+++ b/.github/workflows/Synchronizing.yml
@@ -2,6 +2,7 @@ name: Synchronizing Cloudformation repo with serverless
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:

--- a/.github/workflows/Synchronizing.yml
+++ b/.github/workflows/Synchronizing.yml
@@ -1,5 +1,8 @@
 name: Synchronizing Cloudformation repo with serverless
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,5 +1,8 @@
 name: Infrastructure
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 10 * * 1'  # Every Monday at 10:00 UTC

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore: [master]

--- a/src/helper/requirements.txt
+++ b/src/helper/requirements.txt
@@ -1,2 +1,2 @@
 cfnresponse
-urllib3==2.5.0
+urllib3==2.7.0

--- a/src/lambda-secretLayer/wrapper16.js
+++ b/src/lambda-secretLayer/wrapper16.js
@@ -8,7 +8,7 @@ async function getSecret() {
   AWS.config.update({region:process.env.AWS_REGION});
   const secretsManager = new AWS.SecretsManager();
   // const secretName = process.env.SECRET_NAME;
-  const secretName = process.env.SECRET_NAME || "lambda/coralogix/" + process.env.AWS_REGION + "/" + process.env.AWS_LAMBDA_FUNCTION_NAME;  console.log(secretName);
+  const secretName = process.env.SECRET_NAME || "lambda/coralogix/" + process.env.AWS_REGION + "/" + process.env.AWS_LAMBDA_FUNCTION_NAME;
   const params = {
     SecretId: secretName
   };

--- a/src/lambda-secretLayer/wrapper18.js
+++ b/src/lambda-secretLayer/wrapper18.js
@@ -5,7 +5,7 @@ const { writeFile } = require("fs");
 async function getSecret() {
   const client = new SecretsManagerClient({ region: process.env.AWS_REGION });
 
-  const secretName = process.env.SECRET_NAME || "lambda/coralogix/" + process.env.AWS_REGION + "/" + process.env.AWS_LAMBDA_FUNCTION_NAME;  console.log(secretName);
+  const secretName = process.env.SECRET_NAME || "lambda/coralogix/" + process.env.AWS_REGION + "/" + process.env.AWS_LAMBDA_FUNCTION_NAME;
   
   const command = new GetSecretValueCommand({ SecretId: secretName });
   const secretData = await client.send(command);


### PR DESCRIPTION
## Summary
- bump helper urllib3 from 2.5.0 to 2.7.0 to address the remaining open helper Dependabot alerts
- remove secret-name logging from the lambda-secretLayer wrapper scripts
- add explicit least-privilege permissions blocks to the workflows flagged by code scanning

## Verification
- git diff --check
- node --check src/lambda-secretLayer/wrapper16.js
- node --check src/lambda-secretLayer/wrapper18.js
- ruby -e 'require "yaml"; %w[.github/workflows/release.yaml .github/workflows/infra.yml .github/workflows/Changelog.yaml .github/workflows/Synchronizing.yml].each { |f| YAML.load_file(f) }'

## Follow-up
- helper is still excluded from validate/build/publish in .github/workflows/release.yaml, so that release-path fix should land in a separate PR
- the broader runtime upgrades Roy listed should also stay in separate PRs