### PR TITLE
Fix duplicate lambda-manager subscriptions on failed CreateLogGroup events

### DIFF
--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.11] - 2026-06-13
+### Fixed
+- Ignore failed CloudTrail `CreateLogGroup` events so they do not trigger duplicate subscription work.
+- Skip creating a new subscription when the destination is already attached to the log group.
+
 ## lambda-manager
 
 ## 2.0.10  / 23-06-2025

--- a/src/lambda-manager/lambda_function.py
+++ b/src/lambda-manager/lambda_function.py
@@ -84,11 +84,22 @@ def lambda_handler(event: Dict[str, Any], context) -> None:
 
         # Handle CloudWatch log group creation events
         if scan_old_log_groups != 'true' and "RequestType" not in event:
-            log_group_to_subscribe = event['detail']['requestParameters']['logGroupName']
+            event_detail = event['detail']
+
+            if cloudtrail_event_failed(event_detail):
+                logger.info(
+                    "Skipping failed CloudTrail CreateLogGroup event for %s",
+                    event_detail.get('requestParameters', {}).get('logGroupName', 'unknown log group')
+                )
+                return
+
+            log_group_to_subscribe = event_detail['requestParameters']['logGroupName']
             found_log_group_in_regex_pattern = False
             
             for regex_pattern in regex_pattern_list:
                 if re.match(regex_pattern, log_group_to_subscribe):
+                    if not should_create_subscription(cloudwatch_logs, log_group_to_subscribe, destination_arn):
+                        break
                     if destination_type == 'firehose':
                         logger.info(f"Adding subscription filter for {log_group_to_subscribe}")
                         status = add_subscription(filter_name, logs_filter, log_group_to_subscribe, destination_arn)
@@ -183,28 +194,11 @@ def list_log_groups_and_subscriptions(
     account_id = context.invoked_function_arn.split(":")[4]
     
     for log_group in log_groups:
-        create_subscription = False
         log_group_name = log_group['logGroupName']
 
         for regex_pattern in regex_pattern_list:
             if regex_pattern and re.match(regex_pattern, log_group_name):
-                # Check existing subscriptions
-                subscriptions = cloudwatch_logs.describe_subscription_filters(logGroupName=log_group_name)
-                subscriptions = subscriptions.get('subscriptionFilters')
-
-                if subscriptions is None:
-                    create_subscription = True
-                elif len(subscriptions) < 2:
-                    create_subscription = True
-                    for subscription in subscriptions:
-                        if subscription['destinationArn'] == destination_arn:
-                            create_subscription = False
-                            break
-                elif len(subscriptions) >= 2:
-                    logger.warning(f"Skipping {log_group_name} as it already has 2 subscriptions")
-                    break
-
-                if create_subscription:
+                if should_create_subscription(cloudwatch_logs, log_group_name, destination_arn):
                     if identify_arn_service(destination_arn) == "lambda" and add_permissions_to_all_log_groups == 'false':
                         if not check_if_log_group_exist_in_log_group_permission_prefix(log_group_name, log_group_permission_prefix):
                             add_permission_to_lambda(destination_arn, log_group_name, region, account_id)
@@ -221,6 +215,40 @@ def list_log_groups_and_subscriptions(
                             logger.warning(f"Retrying to add subscription filter for {log_group_name}")
                             add_subscription(filter_name, logs_filter, log_group_name, destination_arn)
                 break  # no need to continue the loop if we find a match for the log group
+
+def cloudtrail_event_failed(event_detail: Dict[str, Any]) -> bool:
+    """
+    Check whether a CloudTrail event represents a failed API call.
+
+    Failed CreateLogGroup events can be retried or emitted for no-op operations such as
+    ResourceAlreadyExistsException. These should not trigger new subscription work.
+    """
+    return bool(event_detail.get('errorCode') or event_detail.get('errorMessage'))
+
+def should_create_subscription(cloudwatch_logs, log_group_name: str, destination_arn: str) -> bool:
+    """
+    Determine whether a log group can accept a new subscription for the destination.
+
+    Returns False when the destination is already subscribed or the log group has already
+    reached the CloudWatch subscription limit.
+    """
+    subscriptions = cloudwatch_logs.describe_subscription_filters(logGroupName=log_group_name)
+    subscriptions = subscriptions.get('subscriptionFilters') or []
+
+    for subscription in subscriptions:
+        if subscription.get('destinationArn') == destination_arn:
+            logger.info(
+                "Skipping %s because a subscription for %s already exists",
+                log_group_name,
+                destination_arn
+            )
+            return False
+
+    if len(subscriptions) >= 2:
+        logger.warning(f"Skipping {log_group_name} as it already has 2 subscriptions")
+        return False
+
+    return True
 
 def add_subscription(
     filter_name: str, 

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -16,7 +16,7 @@ Metadata:
       - cloudwatch
       - lambda
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 2.0.10
+    SemanticVersion: 2.0.11
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/src/lambda-manager/tests/test_lambda_function.py
+++ b/src/lambda-manager/tests/test_lambda_function.py
@@ -1,0 +1,129 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "lambda_function.py"
+
+
+def load_lambda_module():
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = MagicMock(side_effect=[MagicMock(name="logs_client"), MagicMock(name="lambda_client")])
+
+    fake_cfnresponse = types.ModuleType("cfnresponse")
+    fake_cfnresponse.SUCCESS = "SUCCESS"
+    fake_cfnresponse.FAILED = "FAILED"
+    fake_cfnresponse.send = MagicMock()
+
+    fake_botocore = types.ModuleType("botocore")
+    fake_botocore_config = types.ModuleType("botocore.config")
+
+    class FakeConfig:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    fake_botocore_config.Config = FakeConfig
+
+    module_name = "lambda_manager_lambda_function_test"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "boto3": fake_boto3,
+            "botocore": fake_botocore,
+            "botocore.config": fake_botocore_config,
+            "cfnresponse": fake_cfnresponse,
+        },
+    ):
+        spec.loader.exec_module(module)
+
+    return module, fake_cfnresponse
+
+
+class LambdaManagerCreateLogGroupTests(unittest.TestCase):
+    def setUp(self):
+        self.module, self.cfnresponse = load_lambda_module()
+        self.context = SimpleNamespace(
+            invoked_function_arn="arn:aws:lambda:us-east-1:123456789012:function:lambda-manager",
+            function_name="lambda-manager",
+            aws_request_id="request-id",
+        )
+        self.destination_arn = "arn:aws:lambda:us-east-1:123456789012:function:destination"
+
+    def invoke_handler(self, event):
+        env = {
+            "REGEX_PATTERN": "/aws/lambda/.*",
+            "DESTINATION_TYPE": "lambda",
+            "DESTINATION_ARN": self.destination_arn,
+            "SCAN_OLD_LOGGROUPS": "false",
+            "DISABLE_ADD_PERMISSION": "false",
+            "ADD_PERMISSIONS_TO_ALL_LOG_GROUPS": "false",
+            "LOG_GROUP_PERMISSION_PREFIX": "",
+        }
+
+        with patch.dict(os.environ, env, clear=False):
+            self.module.lambda_handler(event, self.context)
+
+    def test_failed_create_log_group_event_is_ignored(self):
+        event = {
+            "detail": {
+                "requestParameters": {"logGroupName": "/aws/lambda/example"},
+                "errorCode": "ResourceAlreadyExistsException",
+                "errorMessage": "The specified log group already exists",
+            }
+        }
+
+        with patch.object(self.module, "add_permission_to_lambda") as add_permission, patch.object(
+            self.module, "add_subscription"
+        ) as add_subscription:
+            self.invoke_handler(event)
+
+        add_permission.assert_not_called()
+        add_subscription.assert_not_called()
+        self.module.cloudwatch_logs.describe_subscription_filters.assert_not_called()
+
+    def test_existing_destination_subscription_is_not_duplicated(self):
+        event = {"detail": {"requestParameters": {"logGroupName": "/aws/lambda/example"}}}
+        self.module.cloudwatch_logs.describe_subscription_filters.return_value = {
+            "subscriptionFilters": [{"destinationArn": self.destination_arn}]
+        }
+
+        with patch.object(self.module, "add_permission_to_lambda") as add_permission, patch.object(
+            self.module, "add_subscription"
+        ) as add_subscription:
+            self.invoke_handler(event)
+
+        self.module.cloudwatch_logs.describe_subscription_filters.assert_called_once_with(
+            logGroupName="/aws/lambda/example"
+        )
+        add_permission.assert_not_called()
+        add_subscription.assert_not_called()
+
+    def test_new_destination_subscription_still_gets_created(self):
+        event = {"detail": {"requestParameters": {"logGroupName": "/aws/lambda/example"}}}
+        self.module.cloudwatch_logs.describe_subscription_filters.return_value = {"subscriptionFilters": []}
+
+        with patch.object(self.module, "add_permission_to_lambda") as add_permission, patch.object(
+            self.module, "add_subscription", return_value=self.cfnresponse.SUCCESS
+        ) as add_subscription:
+            self.invoke_handler(event)
+
+        add_permission.assert_called_once_with(
+            self.destination_arn,
+            "/aws/lambda/example",
+            "us-east-1",
+            "123456789012",
+        )
+        add_subscription.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip failed CloudTrail CreateLogGroup events so ResourceAlreadyExistsException no-ops do not create duplicate subscriptions
- check existing subscription filters before adding a new lambda-manager destination subscription in both the event-driven and scan paths
- add focused unit coverage for failed events, duplicate destinations, and the normal subscribe path

## Verification
- python3 -m unittest src/lambda-manager/tests/test_lambda_function.py
- sam validate (not run locally: sam command unavailable in this shell)

Closes #188