### PR TITLE
Lambda versioning tags groundwork

### DIFF
--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -33,6 +33,7 @@ jobs:
     - name: Check changelog contract
       run: |
         set -euo pipefail
+        base_ref="origin/master"
         changed_files_string="${{ steps.changed-files.outputs.all_changed_files }}"
         read -ra changed_files_array <<< "$changed_files_string"
 
@@ -52,6 +53,11 @@ jobs:
           [[ -n "$package_dir" ]] || continue
 
           if [[ ! -f "$package_dir/template.yaml" ]]; then
+            if git cat-file -e "${base_ref}:${package_dir}/template.yaml" 2>/dev/null; then
+              echo "Missing $package_dir/template.yaml for previously published lambda package $package_dir." >&2
+              exit 1
+            fi
+
             echo "Skipping $package_dir because it is not a published lambda package."
             continue
           fi

--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -30,13 +30,37 @@ jobs:
       id: changed-files
       uses: tj-actions/changed-files@v46.0.1
 
-    - name: Check changelog file 
+    - name: Check changelog contract
       run: |
+        set -euo pipefail
         changed_files_string="${{ steps.changed-files.outputs.all_changed_files }}"
         read -ra changed_files_array <<< "$changed_files_string"
-        chmod +x scripts/changelog_check.sh
-        for changed_file in "${changed_files_array[@]}"; do
-          if [[ "$changed_file" == *"/template."* ]]; then
-            scripts/changelog_check.sh $(dirname $changed_file)
+
+        package_dirs="$(
+          printf '%s\n' "${changed_files_array[@]}" \
+            | awk -F/ '$1 == "src" && $2 != "" { print $1 "/" $2 }' \
+            | sort -u
+        )"
+
+        if [[ -z "$package_dirs" ]]; then
+          echo "No src/<name>/ changes detected."
+          exit 0
+        fi
+
+        checked_count=0
+        while IFS= read -r package_dir; do
+          [[ -n "$package_dir" ]] || continue
+
+          if [[ ! -f "$package_dir/template.yaml" || ! -f "$package_dir/CHANGELOG.md" ]]; then
+            echo "Skipping $package_dir because it is not a published lambda package."
+            continue
           fi
-        done
+
+          echo "Checking changelog contract for $package_dir"
+          bash scripts/changelog_check.sh "$package_dir"
+          checked_count=$((checked_count + 1))
+        done <<< "$package_dirs"
+
+        if [[ "$checked_count" -eq 0 ]]; then
+          echo "No published lambda packages required changelog validation."
+        fi

--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -51,9 +51,14 @@ jobs:
         while IFS= read -r package_dir; do
           [[ -n "$package_dir" ]] || continue
 
-          if [[ ! -f "$package_dir/template.yaml" || ! -f "$package_dir/CHANGELOG.md" ]]; then
+          if [[ ! -f "$package_dir/template.yaml" ]]; then
             echo "Skipping $package_dir because it is not a published lambda package."
             continue
+          fi
+
+          if [[ ! -f "$package_dir/CHANGELOG.md" ]]; then
+            echo "Missing $package_dir/CHANGELOG.md for published lambda package $package_dir." >&2
+            exit 1
           fi
 
           echo "Checking changelog contract for $package_dir"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin master:refs/remotes/origin/master --depth=1
+          git fetch origin master:refs/remotes/origin/master
           bash scripts/release_publish_preflight.sh "$GITHUB_REF_NAME" origin/master "${GITHUB_REF_NAME}^{commit}" > preflight.env
           cat preflight.env >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,166 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*-v*.*.*'
+      - '*-*.*.*'
+
+env:
+  AWS_DEFAULT_REGION: eu-central-1
+  AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
+
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    outputs:
+      trigger_tag: ${{ steps.preflight.outputs.trigger_tag }}
+      canonical_tag: ${{ steps.preflight.outputs.canonical_tag }}
+      tag_variant: ${{ steps.preflight.outputs.tag_variant }}
+      package: ${{ steps.preflight.outputs.package }}
+      package_dir: ${{ steps.preflight.outputs.package_dir }}
+      version: ${{ steps.preflight.outputs.version }}
+      application_name: ${{ steps.preflight.outputs.application_name }}
+      commit_sha: ${{ steps.preflight.outputs.commit_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve publish target
+        id: preflight
+        run: |
+          set -euo pipefail
+
+          git fetch origin master:refs/remotes/origin/master --depth=1
+          bash scripts/release_publish_preflight.sh "$GITHUB_REF_NAME" origin/master "${GITHUB_REF_NAME}^{commit}" > preflight.env
+          cat preflight.env >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: preflight
+    permissions:
+      contents: write
+    concurrency:
+      group: sar-publish-${{ needs.preflight.outputs.package }}-${{ needs.preflight.outputs.version }}
+      cancel-in-progress: false
+    env:
+      PACKAGE: ${{ needs.preflight.outputs.package }}
+      PACKAGE_DIR: ${{ needs.preflight.outputs.package_dir }}
+      VERSION: ${{ needs.preflight.outputs.version }}
+      APPLICATION_NAME: ${{ needs.preflight.outputs.application_name }}
+      CANONICAL_TAG: ${{ needs.preflight.outputs.canonical_tag }}
+      TAG_VARIANT: ${{ needs.preflight.outputs.tag_variant }}
+      COMMIT_SHA: ${{ needs.preflight.outputs.commit_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Check published SAR version
+        id: sar-version
+        run: |
+          set -euo pipefail
+
+          account_id="$(aws sts get-caller-identity --query 'Account' --output text)"
+          application_id="arn:aws:serverlessrepo:${AWS_DEFAULT_REGION}:${account_id}:applications/${APPLICATION_NAME}"
+
+          if versions_json="$(aws serverlessrepo list-application-versions --application-id "$application_id" --output json 2>versions.err)"; then
+            if jq -e --arg version "$VERSION" '.Versions[]? | select(.SemanticVersion == $version)' <<<"$versions_json" >/dev/null; then
+              echo "version_exists=true" >> "$GITHUB_OUTPUT"
+              echo "SAR version ${VERSION} is already published for ${APPLICATION_NAME}; skipping publish steps."
+            else
+              echo "version_exists=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            if grep -Eiq 'not.?found|ResourceNotFoundException' versions.err; then
+              echo "version_exists=false" >> "$GITHUB_OUTPUT"
+            else
+              cat versions.err >&2
+              exit 1
+            fi
+          fi
+
+      - if: ${{ steps.sar-version.outputs.version_exists != 'true' }}
+        name: Build
+        working-directory: ./${{ env.PACKAGE_DIR }}
+        run: sam build --use-container
+
+      - if: ${{ steps.sar-version.outputs.version_exists != 'true' }}
+        name: Package
+        working-directory: ./${{ env.PACKAGE_DIR }}
+        run: |
+          sam package \
+            --s3-bucket "${AWS_SERVERLESS_BUCKET}" \
+            --s3-prefix "${PACKAGE}" \
+            --output-template-file packaged.yaml
+
+      - if: ${{ steps.sar-version.outputs.version_exists != 'true' }}
+        name: Publish to SAR
+        working-directory: ./${{ env.PACKAGE_DIR }}
+        run: sam publish --template packaged.yaml
+
+      - if: ${{ steps.sar-version.outputs.version_exists != 'true' && env.PACKAGE == 'resource-metadata-sqs' }}
+        name: StoreMultiFunction
+        working-directory: ./${{ env.PACKAGE_DIR }}
+        run: |
+          aws s3 cp \
+            "$(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "CollectorLambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml)" \
+            "s3://${AWS_SERVERLESS_BUCKET}-${AWS_DEFAULT_REGION}/${PACKAGE}-collector.zip"
+          aws s3 cp \
+            "$(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "GeneratorLambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml)" \
+            "s3://${AWS_SERVERLESS_BUCKET}-${AWS_DEFAULT_REGION}/${PACKAGE}-generator.zip"
+
+      - if: ${{ steps.sar-version.outputs.version_exists != 'true' && env.PACKAGE != 'resource-metadata-sqs' }}
+        name: Store
+        working-directory: ./${{ env.PACKAGE_DIR }}
+        run: |
+          aws s3 cp \
+            "$(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "LambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml)" \
+            "s3://${AWS_SERVERLESS_BUCKET}-${AWS_DEFAULT_REGION}/${PACKAGE}.zip"
+
+      - if: ${{ env.TAG_VARIANT == 'alias' }}
+        name: Ensure canonical tag
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${CANONICAL_TAG}" >/dev/null 2>&1; then
+            echo "Canonical tag ${CANONICAL_TAG} already exists."
+            exit 0
+          fi
+
+          git tag "${CANONICAL_TAG}" "${COMMIT_SHA}"
+          git push origin "refs/tags/${CANONICAL_TAG}"
+
+      - name: Generate release notes
+        run: bash scripts/changelog_release_notes.sh "${PACKAGE_DIR}" "${VERSION}" > release-notes.md
+
+      - name: Create canonical GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "${CANONICAL_TAG}" >/dev/null 2>&1; then
+            echo "Release ${CANONICAL_TAG} already exists; skipping release creation."
+            exit 0
+          fi
+
+          gh release create "${CANONICAL_TAG}" \
+            --verify-tag \
+            --title "${CANONICAL_TAG}" \
+            --notes-file release-notes.md

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      - if: ${{ env.TAG_VARIANT == 'alias' }}
+        id: canonical-tag-check
+        name: Validate canonical tag target
+        run: |
+          set -euo pipefail
+
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${CANONICAL_TAG}" >/dev/null 2>&1; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Canonical tag ${CANONICAL_TAG} does not exist yet."
+            exit 0
+          fi
+
+          tmp_ref="refs/tags/__tmp_canonical_tag_check"
+          git fetch --no-tags origin "refs/tags/${CANONICAL_TAG}:${tmp_ref}"
+          remote_commit_sha="$(git rev-parse "${tmp_ref}^{commit}")"
+          git update-ref -d "$tmp_ref"
+
+          if [[ "${remote_commit_sha}" != "${COMMIT_SHA}" ]]; then
+            echo "Canonical tag ${CANONICAL_TAG} already points to ${remote_commit_sha}, expected ${COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "Canonical tag ${CANONICAL_TAG} already exists on ${COMMIT_SHA}."
+
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
@@ -134,25 +159,10 @@ jobs:
             "$(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "LambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml)" \
             "s3://${AWS_SERVERLESS_BUCKET}-${AWS_DEFAULT_REGION}/${PACKAGE}.zip"
 
-      - if: ${{ env.TAG_VARIANT == 'alias' }}
+      - if: ${{ env.TAG_VARIANT == 'alias' && steps.canonical-tag-check.outputs.exists != 'true' }}
         name: Ensure canonical tag
         run: |
           set -euo pipefail
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${CANONICAL_TAG}" >/dev/null 2>&1; then
-            tmp_ref="refs/tags/__tmp_canonical_tag_check"
-            git fetch --no-tags origin "refs/tags/${CANONICAL_TAG}:${tmp_ref}"
-            remote_commit_sha="$(git rev-parse "${tmp_ref}^{commit}")"
-            git update-ref -d "$tmp_ref"
-
-            if [[ "${remote_commit_sha}" != "${COMMIT_SHA}" ]]; then
-              echo "Canonical tag ${CANONICAL_TAG} already points to ${remote_commit_sha}, expected ${COMMIT_SHA}." >&2
-              exit 1
-            fi
-
-            echo "Canonical tag ${CANONICAL_TAG} already exists on ${COMMIT_SHA}."
-            exit 0
-          fi
 
           git tag "${CANONICAL_TAG}" "${COMMIT_SHA}"
           git push origin "refs/tags/${CANONICAL_TAG}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,9 @@ on:
       - '*-v*.*.*'
       - '*-*.*.*'
 
+permissions:
+  contents: read
+
 env:
   AWS_DEFAULT_REGION: eu-central-1
   AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
@@ -82,7 +85,7 @@ jobs:
           if versions_json="$(aws serverlessrepo list-application-versions --application-id "$application_id" --output json 2>versions.err)"; then
             if jq -e --arg version "$VERSION" '.Versions[]? | select(.SemanticVersion == $version)' <<<"$versions_json" >/dev/null; then
               echo "version_exists=true" >> "$GITHUB_OUTPUT"
-              echo "SAR version ${VERSION} is already published for ${APPLICATION_NAME}; skipping publish steps."
+              echo "SAR version ${VERSION} is already published for ${APPLICATION_NAME}; skipping only the SAR publish step so S3 artifacts can still be repaired."
             else
               echo "version_exists=false" >> "$GITHUB_OUTPUT"
             fi
@@ -95,13 +98,11 @@ jobs:
             fi
           fi
 
-      - if: ${{ steps.sar-version.outputs.version_exists != 'true' }}
-        name: Build
+      - name: Build
         working-directory: ./${{ env.PACKAGE_DIR }}
         run: sam build --use-container
 
-      - if: ${{ steps.sar-version.outputs.version_exists != 'true' }}
-        name: Package
+      - name: Package
         working-directory: ./${{ env.PACKAGE_DIR }}
         run: |
           sam package \
@@ -114,7 +115,7 @@ jobs:
         working-directory: ./${{ env.PACKAGE_DIR }}
         run: sam publish --template packaged.yaml
 
-      - if: ${{ steps.sar-version.outputs.version_exists != 'true' && env.PACKAGE == 'resource-metadata-sqs' }}
+      - if: ${{ env.PACKAGE == 'resource-metadata-sqs' }}
         name: StoreMultiFunction
         working-directory: ./${{ env.PACKAGE_DIR }}
         run: |
@@ -125,7 +126,7 @@ jobs:
             "$(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "GeneratorLambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml)" \
             "s3://${AWS_SERVERLESS_BUCKET}-${AWS_DEFAULT_REGION}/${PACKAGE}-generator.zip"
 
-      - if: ${{ steps.sar-version.outputs.version_exists != 'true' && env.PACKAGE != 'resource-metadata-sqs' }}
+      - if: ${{ env.PACKAGE != 'resource-metadata-sqs' }}
         name: Store
         working-directory: ./${{ env.PACKAGE_DIR }}
         run: |
@@ -139,7 +140,17 @@ jobs:
           set -euo pipefail
 
           if git ls-remote --exit-code --tags origin "refs/tags/${CANONICAL_TAG}" >/dev/null 2>&1; then
-            echo "Canonical tag ${CANONICAL_TAG} already exists."
+            tmp_ref="refs/tags/__tmp_canonical_tag_check"
+            git fetch --no-tags origin "refs/tags/${CANONICAL_TAG}:${tmp_ref}"
+            remote_commit_sha="$(git rev-parse "${tmp_ref}^{commit}")"
+            git update-ref -d "$tmp_ref"
+
+            if [[ "${remote_commit_sha}" != "${COMMIT_SHA}" ]]; then
+              echo "Canonical tag ${CANONICAL_TAG} already points to ${remote_commit_sha}, expected ${COMMIT_SHA}." >&2
+              exit 1
+            fi
+
+            echo "Canonical tag ${CANONICAL_TAG} already exists on ${COMMIT_SHA}."
             exit 0
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,6 +106,8 @@ jobs:
     name: Publish
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
     needs: 
@@ -116,6 +118,11 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.check.outputs.packages) }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
@@ -153,3 +160,34 @@ jobs:
           aws s3 cp \
             $(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "LambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml) \
             s3://${{ env.AWS_SERVERLESS_BUCKET }}-${{ env.AWS_DEFAULT_REGION }}/${{ matrix.package }}.zip
+
+      - if: ${{ matrix.package != 'helper' }}
+        name: Create git tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          package_dir="src/${{ matrix.package }}"
+          version="$(sed -n 's/^[[:space:]]*SemanticVersion:[[:space:]]*//p' "$package_dir/template.yaml" | head -n1 | tr -d '"\r' | xargs)"
+          if [[ -z "$version" ]]; then
+            echo "Could not determine SemanticVersion for $package_dir" >&2
+            exit 1
+          fi
+
+          tag="${{ matrix.package }}-v${version}"
+          target_sha="${{ github.event.pull_request.merge_commit_sha }}"
+          if [[ -z "$target_sha" || "$target_sha" == "null" ]]; then
+            target_sha="$GITHUB_SHA"
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag $tag already exists; skipping release creation."
+            exit 0
+          fi
+
+          bash scripts/changelog_release_notes.sh "$package_dir" "$version" > release-notes.md
+          gh release create "$tag" \
+            --target "$target_sha" \
+            --title "$tag" \
+            --notes-file release-notes.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,8 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     outputs:
-      packages: ${{ env.packages }}
+      packages: ${{ steps.get-changed-packages.outputs.packages }}
+      publish_packages: ${{ steps.get-changed-packages.outputs.publish_packages }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,8 +27,27 @@ jobs:
       - name: Get Changed Packages
         id: get-changed-packages
         run: |
-          export PACKAGES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha || 'origin/master' }} ${{ github.sha }} src/ | xargs -n1 dirname | sed -r 's/src\/([^\/]+).*$/src\/\1/g' | xargs -n1 basename | sort | uniq | jq -rcnR '[inputs]')
-          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          set -euo pipefail
+
+          base_ref="${{ github.event.pull_request.base.sha || 'origin/master' }}"
+          changed_files="$(git diff --name-only --diff-filter=d "${base_ref}...${{ github.sha }}" -- src/)"
+
+          packages="$(
+            printf '%s\n' "$changed_files" \
+              | awk -F/ '$1 == "src" && $2 != "" { print $2 }' \
+              | sort -u \
+              | jq -rcnR '[inputs | select(length > 0)]'
+          )"
+
+          publish_packages="$(
+            printf '%s\n' "$changed_files" \
+              | awk -F/ '$1 == "src" && $2 != "" && $2 != "helper" && $3 != "CHANGELOG.md" { print $2 }' \
+              | sort -u \
+              | jq -rcnR '[inputs | select(length > 0)]'
+          )"
+
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+          echo "publish_packages=$publish_packages" >> "$GITHUB_OUTPUT"
 
   validate:
     name: Validate
@@ -104,7 +124,7 @@ jobs:
 
   publish:
     name: Publish
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && needs.check.outputs.publish_packages != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -116,7 +136,7 @@ jobs:
 
     strategy:
       matrix:
-        package: ${{ fromJSON(needs.check.outputs.packages) }}
+        package: ${{ fromJSON(needs.check.outputs.publish_packages) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -181,13 +201,21 @@ jobs:
             target_sha="$GITHUB_SHA"
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "Tag $tag already exists; skipping release creation."
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists; skipping release creation."
             exit 0
           fi
 
           bash scripts/changelog_release_notes.sh "$package_dir" "$version" > release-notes.md
-          gh release create "$tag" \
-            --target "$target_sha" \
-            --title "$tag" \
-            --notes-file release-notes.md
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --verify-tag \
+              --title "$tag" \
+              --notes-file release-notes.md
+          else
+            gh release create "$tag" \
+              --target "$target_sha" \
+              --title "$tag" \
+              --notes-file release-notes.md
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+# Branch-side validation only. Tag-triggered publish and release creation live in .github/workflows/publish.yaml.
 name: Release Checks
 
 on:
@@ -19,6 +20,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Run release publish preflight tests
+        run: bash scripts/release_publish_preflight_test.sh
 
       - name: Get Changed Packages
         id: get-changed-packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,8 @@
-name: Release
+name: Release Checks
 
 on:
   push:
     branches-ignore: [master]
-  pull_request:
-    types: [closed]
-    branches: [master]
 
 env:
   AWS_DEFAULT_REGION: eu-central-1
@@ -16,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.get-changed-packages.outputs.packages }}
-      publish_packages: ${{ steps.get-changed-packages.outputs.publish_packages }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +25,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          base_ref="${{ github.event.pull_request.base.sha || 'origin/master' }}"
+          base_ref="origin/master"
           changed_files="$(git diff --name-only --diff-filter=d "${base_ref}...${{ github.sha }}" -- src/)"
 
           packages="$(
@@ -39,24 +35,7 @@ jobs:
               | jq -rcnR '[inputs | select(length > 0)]'
           )"
 
-          skip_changelog=false
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && jq -e '.pull_request.labels[]?.name | select(. == "skip-changelog")' "$GITHUB_EVENT_PATH" >/dev/null; then
-            skip_changelog=true
-          fi
-
-          if [[ "$skip_changelog" == "true" ]]; then
-            publish_packages='[]'
-          else
-            publish_packages="$(
-              printf '%s\n' "$changed_files" \
-                | awk -F/ '$1 == "src" && $2 != "" && $2 != "helper" && $3 != "CHANGELOG.md" { print $2 }' \
-                | sort -u \
-                | jq -rcnR '[inputs | select(length > 0)]'
-            )"
-          fi
-
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
-          echo "publish_packages=$publish_packages" >> "$GITHUB_OUTPUT"
 
   validate:
     name: Validate
@@ -89,8 +68,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
     needs: [check, validate]
     strategy:
       matrix:
@@ -114,117 +91,3 @@ jobs:
         name: Build
         working-directory: ./src/${{ matrix.package }}
         run: sam build --use-container
-
-      - name: Package
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && matrix.package != 'helper'}}
-        working-directory: ./src/${{ matrix.package }}
-        run: |
-          sam package \
-            --s3-bucket ${{ env.AWS_SERVERLESS_BUCKET }} \
-            --s3-prefix ${{ matrix.package }} \
-            --output-template-file packaged.yaml
-
-      - name: Store
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && matrix.package != 'helper' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.package }}-packaged.yaml
-          path: src/${{ matrix.package }}/packaged.yaml
-
-  publish:
-    name: Publish
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && needs.check.outputs.publish_packages != '[]' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
-    needs: 
-      - check
-      - build
-
-    strategy:
-      matrix:
-        package: ${{ fromJSON(needs.check.outputs.publish_packages) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
-
-      - if: ${{ matrix.package != 'helper' }}
-        name: Download
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.package }}-packaged.yaml
-
-      - if: ${{ matrix.package != 'helper' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-      - if: ${{ matrix.package != 'helper' }}
-        name: Publish
-        run: sam publish --template packaged.yaml
-
-      - if: ${{ matrix.package == 'resource-metadata-sqs' }}
-        name: StoreMultiFunction
-        run: |
-          aws s3 cp \
-            $(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "CollectorLambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml) \
-            s3://${{ env.AWS_SERVERLESS_BUCKET }}-${{ env.AWS_DEFAULT_REGION }}/${{ matrix.package }}-collector.zip
-          aws s3 cp \
-            $(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "GeneratorLambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml) \
-            s3://${{ env.AWS_SERVERLESS_BUCKET }}-${{ env.AWS_DEFAULT_REGION }}/${{ matrix.package }}-generator.zip
-
-      - if: ${{ !contains(fromJson('["helper", "resource-metadata-sqs"]'), matrix.package) }}
-        name: Store
-        run: |
-          aws s3 cp \
-            $(yq -r '.Resources | to_entries | .[] | select(.key == "LambdaLayer" or .key == "LambdaFunction") | .value.Properties | to_entries | .[] | select(.key == "ContentUri" or .key == "CodeUri") | .value' packaged.yaml) \
-            s3://${{ env.AWS_SERVERLESS_BUCKET }}-${{ env.AWS_DEFAULT_REGION }}/${{ matrix.package }}.zip
-
-      - if: ${{ matrix.package != 'helper' }}
-        name: Create git tag and GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          package_dir="src/${{ matrix.package }}"
-          version="$(sed -n 's/^[[:space:]]*SemanticVersion:[[:space:]]*//p' "$package_dir/template.yaml" | head -n1 | tr -d '"\r' | xargs)"
-          if [[ -z "$version" ]]; then
-            echo "Could not determine SemanticVersion for $package_dir" >&2
-            exit 1
-          fi
-
-          tag="${{ matrix.package }}-v${version}"
-          target_sha="${{ github.event.pull_request.merge_commit_sha }}"
-          if [[ -z "$target_sha" || "$target_sha" == "null" ]]; then
-            target_sha="$GITHUB_SHA"
-          fi
-
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "Release $tag already exists; skipping release creation."
-            exit 0
-          fi
-
-          bash scripts/changelog_release_notes.sh "$package_dir" "$version" > release-notes.md
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-            gh release create "$tag" \
-              --verify-tag \
-              --title "$tag" \
-              --notes-file release-notes.md
-          else
-            gh release create "$tag" \
-              --target "$target_sha" \
-              --title "$tag" \
-              --notes-file release-notes.md
-          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,12 +39,21 @@ jobs:
               | jq -rcnR '[inputs | select(length > 0)]'
           )"
 
-          publish_packages="$(
-            printf '%s\n' "$changed_files" \
-              | awk -F/ '$1 == "src" && $2 != "" && $2 != "helper" && $3 != "CHANGELOG.md" { print $2 }' \
-              | sort -u \
-              | jq -rcnR '[inputs | select(length > 0)]'
-          )"
+          skip_changelog=false
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && jq -e '.pull_request.labels[]?.name | select(. == "skip-changelog")' "$GITHUB_EVENT_PATH" >/dev/null; then
+            skip_changelog=true
+          fi
+
+          if [[ "$skip_changelog" == "true" ]]; then
+            publish_packages='[]'
+          else
+            publish_packages="$(
+              printf '%s\n' "$changed_files" \
+                | awk -F/ '$1 == "src" && $2 != "" && $2 != "helper" && $3 != "CHANGELOG.md" { print $2 }' \
+                | sort -u \
+                | jq -rcnR '[inputs | select(length > 0)]'
+            )"
+          fi
 
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
           echo "publish_packages=$publish_packages" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Release Conventions For Coding Agents
+
+Use this file when changing published lambda packages under `src/<name>/` or the workflows that release them.
+
+## Versioning
+
+- Treat `Metadata.AWS::ServerlessRepo::Application.SemanticVersion` in `src/<name>/template.yaml` as the only published version source of truth.
+- If a published package changes beyond `CHANGELOG.md`, bump `SemanticVersion`.
+- Do not reuse an old published version number. AWS SAR versions are immutable, so any fix after publish must move to a new version on a new commit.
+
+## Changelog
+
+- Keep `src/<name>/CHANGELOG.md` for every published package.
+- The first release heading must be `## [X.Y.Z] - YYYY-MM-DD`.
+- The top changelog version must match `template.yaml` `SemanticVersion`.
+- The top release entry must contain at least one bullet.
+- Changelog-only edits do not require a `SemanticVersion` bump.
+- Use the `skip-changelog` PR label only when a package change does not require either a changelog entry or a version bump.
+
+## Publishing
+
+- Merge to `master` does not publish a package.
+- Publishing is triggered by pushing a package tag on the merged `master` commit you want to promote.
+- Accepted trigger tags are `<name>-v<X.Y.Z>` and `<name>-<X.Y.Z>`.
+- Both tag forms publish the same package version, but `<name>-v<X.Y.Z>` is the canonical GitHub Release identity.
+- If the bare alias tag is pushed first, the workflow backfills the canonical `<name>-v<X.Y.Z>` tag after successful publish.
+
+## Maintainer Flow
+
+1. Merge the package change to `master`.
+2. Validate the merged commit you want to promote.
+3. Confirm `src/<name>/template.yaml` `SemanticVersion` matches the top `src/<name>/CHANGELOG.md` release.
+4. Push either `git tag <name>-v<X.Y.Z>` or `git tag <name>-<X.Y.Z>` on that merged commit.
+5. Push the tag to `origin` to trigger publishing.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,3 +3,12 @@ AWS S3 Lambda function for Coralogix is written and maintained by Coralogix Ltd.
 # Contributors  
 
 * Coralogix Ltd. <[info@coralogix.com](mailto:info@coralogix.com)> [@coralogix](https://github.com/coralogix)
+
+## Contribution Notes
+
+For published lambda packages in `src/<name>/`:
+
+- Keep `template.yaml` `SemanticVersion` and the top `CHANGELOG.md` entry in sync.
+- Format the top changelog entry as `## [X.Y.Z] - YYYY-MM-DD` and include at least one bullet.
+- Expect merged releases to publish a matching `<name>-v<X.Y.Z>` Git tag and GitHub Release automatically.
+- Use the `skip-changelog` label only when the change does not need a changelog update or version bump.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@
 Deprecated integrations have been removed from this repository.
 
 **For historical reference**, the complete code and documentation for these deprecated integrations is preserved in the [`deprecated-integrations-archive`](https://github.com/coralogix/coralogix-aws-serverless/tree/deprecated-integrations-archive) branch.
+
+## Published Lambda Versioning
+
+For published lambda packages under `src/<name>/`:
+
+- Bump `Metadata.AWS::ServerlessRepo::Application.SemanticVersion` in `template.yaml` whenever the package changes beyond `CHANGELOG.md`.
+- Keep the first `CHANGELOG.md` release heading in `## [X.Y.Z] - YYYY-MM-DD` format, with `X.Y.Z` matching `SemanticVersion` and at least one bullet under that release.
+- Merged releases create a per-package Git tag and GitHub Release in the form `<name>-v<X.Y.Z>`.
+- Use the `skip-changelog` PR label only when a package change does not require a changelog entry or version bump.

--- a/README.md
+++ b/README.md
@@ -12,5 +12,12 @@ For published lambda packages under `src/<name>/`:
 
 - Bump `Metadata.AWS::ServerlessRepo::Application.SemanticVersion` in `template.yaml` whenever the package changes beyond `CHANGELOG.md`.
 - Keep the first `CHANGELOG.md` release heading in `## [X.Y.Z] - YYYY-MM-DD` format, with `X.Y.Z` matching `SemanticVersion` and at least one bullet under that release.
-- Merged releases create a per-package Git tag and GitHub Release in the form `<name>-v<X.Y.Z>`.
+- Merge to `master` does not publish by itself. Promotion happens after merge by pushing a per-package tag from the merged `master` commit you want to release.
+- Accepted publish tags are `<name>-v<X.Y.Z>` and `<name>-<X.Y.Z>`. Both trigger the same single-package SAR publish flow, and `<name>-v<X.Y.Z>` is the canonical GitHub Release identity.
+- Maintainer flow:
+  1. Merge the package change to `master` and validate the merged commit.
+  2. Confirm `src/<name>/template.yaml` `SemanticVersion` and the top `src/<name>/CHANGELOG.md` entry both match `X.Y.Z`.
+  3. Push either `git tag <name>-v<X.Y.Z>` or `git tag <name>-<X.Y.Z>` on that merged commit, then `git push origin <tag>`.
+  4. If the bare alias tag is pushed first, the workflow backfills the canonical `<name>-v<X.Y.Z>` tag and creates the GitHub Release there.
+  5. If a published build has an issue, ship a new commit with a new `SemanticVersion`; AWS SAR versions are immutable and cannot be reused.
 - Use the `skip-changelog` PR label only when a package change does not require a changelog entry or version bump.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,36 @@ Deprecated integrations have been removed from this repository.
 
 ## Published Lambda Versioning
 
-For published lambda packages under `src/<name>/`:
+These rules apply to the published lambda packages under `src/<name>/`.
 
-- Bump `Metadata.AWS::ServerlessRepo::Application.SemanticVersion` in `template.yaml` whenever the package changes beyond `CHANGELOG.md`.
-- Keep the first `CHANGELOG.md` release heading in `## [X.Y.Z] - YYYY-MM-DD` format, with `X.Y.Z` matching `SemanticVersion` and at least one bullet under that release.
-- Merge to `master` does not publish by itself. Promotion happens after merge by pushing a per-package tag from the merged `master` commit you want to release.
-- Accepted publish tags are `<name>-v<X.Y.Z>` and `<name>-<X.Y.Z>`. Both trigger the same single-package SAR publish flow, and `<name>-v<X.Y.Z>` is the canonical GitHub Release identity.
-- Maintainer flow:
-  1. Merge the package change to `master` and validate the merged commit.
-  2. Confirm `src/<name>/template.yaml` `SemanticVersion` and the top `src/<name>/CHANGELOG.md` entry both match `X.Y.Z`.
-  3. Push either `git tag <name>-v<X.Y.Z>` or `git tag <name>-<X.Y.Z>` on that merged commit, then `git push origin <tag>`.
-  4. If the bare alias tag is pushed first, the workflow backfills the canonical `<name>-v<X.Y.Z>` tag and creates the GitHub Release there.
-  5. If a published build has an issue, ship a new commit with a new `SemanticVersion`; AWS SAR versions are immutable and cannot be reused.
+### Versioning expectations
+
+- `Metadata.AWS::ServerlessRepo::Application.SemanticVersion` in `template.yaml` is the single source of truth for the published package version.
+- Bump `SemanticVersion` whenever a published package changes beyond `CHANGELOG.md`.
+- Do not try to reuse a previously published version number. AWS SAR versions are immutable, so fixes after a bad publish must ship as a new version on a new commit.
+
+### Changelog expectations
+
+- Each published package must keep `src/<name>/CHANGELOG.md`.
+- The first release heading must be `## [X.Y.Z] - YYYY-MM-DD`.
+- `X.Y.Z` in that first heading must match `template.yaml` `SemanticVersion`.
+- The top release entry must include at least one bullet describing the release.
+- A changelog-only edit does not require a `SemanticVersion` bump.
 - Use the `skip-changelog` PR label only when a package change does not require a changelog entry or version bump.
+
+### Publishing expectations
+
+- Merge to `master` does not publish by itself.
+- Promotion happens after merge by pushing a package release tag on the merged `master` commit you want to release.
+- Accepted publish tags are `<name>-v<X.Y.Z>` and `<name>-<X.Y.Z>`.
+- Both tag forms trigger the same single-package SAR publish workflow.
+- `<name>-v<X.Y.Z>` is the canonical outward release identity and the GitHub Release name.
+- If the bare alias tag is pushed first, the workflow backfills the canonical `<name>-v<X.Y.Z>` tag and creates the GitHub Release there.
+
+### Maintainer flow
+
+1. Merge the package change to `master`.
+2. Validate the merged commit you intend to promote.
+3. Confirm `src/<name>/template.yaml` `SemanticVersion` and the top `src/<name>/CHANGELOG.md` entry both match `X.Y.Z`.
+4. Push either `git tag <name>-v<X.Y.Z>` or `git tag <name>-<X.Y.Z>` on that merged commit.
+5. Run `git push origin <tag>` to trigger the publish workflow.

--- a/scripts/changelog_check.sh
+++ b/scripts/changelog_check.sh
@@ -1,11 +1,102 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Simply check if diff in changelog exists.
-git diff --exit-code --quiet origin/master... ./$1/CHANGELOG.md
-if [ $? -ne 1 ]; then
-  echo "Following files have been changed:"
-  echo $(git diff --name-only origin/master... ./$1)
-  echo ""
-  echo "Please add a changelog entry in $1/CHANGELOG.md or add 'skip changelog' label to your PR if this change does not require an entry".
+set -euo pipefail
+
+package_dir="${1:-}"
+base_ref="${2:-origin/master}"
+
+fail() {
+  echo "changelog_check: $*" >&2
   exit 1
+}
+
+extract_semver_from_stream() {
+  sed -n 's/^[[:space:]]*SemanticVersion:[[:space:]]*//p' \
+    | head -n1 \
+    | tr -d '"\r' \
+    | xargs
+}
+
+semver_gt() {
+  local left="$1"
+  local right="$2"
+
+  [[ "$left" != "$right" ]] && [[ "$(printf '%s\n%s\n' "$right" "$left" | sort -V | tail -n1)" == "$left" ]]
+}
+
+top_section_has_bullet() {
+  local changelog_path="$1"
+
+  awk '
+    BEGIN { in_top_section = 0; found_bullet = 0 }
+    /^## \[/ {
+      if (in_top_section) {
+        exit
+      }
+      in_top_section = 1
+      next
+    }
+    in_top_section && /^[[:space:]]*-[[:space:]]/ {
+      found_bullet = 1
+    }
+    END {
+      exit(found_bullet ? 0 : 1)
+    }
+  ' "$changelog_path"
+}
+
+if [[ -z "$package_dir" ]]; then
+  fail "usage: scripts/changelog_check.sh <src/package-dir> [base-ref]"
 fi
+
+package_dir="${package_dir#./}"
+package_dir="${package_dir%/}"
+template_path="$package_dir/template.yaml"
+changelog_path="$package_dir/CHANGELOG.md"
+
+[[ -f "$template_path" ]] || fail "missing template file: $template_path"
+[[ -f "$changelog_path" ]] || fail "missing changelog file: $changelog_path"
+
+git rev-parse --verify "$base_ref" >/dev/null 2>&1 || fail "base ref not found: $base_ref"
+
+current_semver="$(extract_semver_from_stream < "$template_path")"
+[[ -n "$current_semver" ]] || fail "could not read SemanticVersion from $template_path"
+
+top_header="$(awk '/^## / { print; exit }' "$changelog_path")"
+[[ -n "$top_header" ]] || fail "missing release heading in $changelog_path"
+[[ "$top_header" =~ ^##\ \[[0-9]+\.[0-9]+\.[0-9]+\]\ -\ [0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+  || fail "top changelog entry in $changelog_path must look like: ## [X.Y.Z] - YYYY-MM-DD"
+
+top_semver="$(printf '%s\n' "$top_header" | sed -E 's/^## \[([^]]+)\] - .*/\1/')"
+if [[ "$top_semver" != "$current_semver" ]]; then
+  fail "top changelog version ($top_semver) does not match $template_path SemanticVersion ($current_semver)"
+fi
+
+top_section_has_bullet "$changelog_path" || fail "top changelog entry in $changelog_path must include at least one bullet"
+
+base_template="$(git show "$base_ref:$template_path" 2>/dev/null || true)"
+base_semver=""
+if [[ -n "$base_template" ]]; then
+  base_semver="$(printf '%s\n' "$base_template" | extract_semver_from_stream)"
+fi
+
+changed_files="$(git diff --name-only "$base_ref"... -- "$package_dir")"
+
+has_non_changelog_changes=0
+while IFS= read -r changed_file; do
+  [[ -n "$changed_file" ]] || continue
+  if [[ "$changed_file" != "$changelog_path" ]]; then
+    has_non_changelog_changes=1
+    break
+  fi
+done <<< "$changed_files"
+
+if [[ "$has_non_changelog_changes" -eq 1 && -n "$base_semver" ]] && ! semver_gt "$current_semver" "$base_semver"; then
+  printf 'changelog_check: package changes detected in %s without a SemanticVersion bump\n' "$package_dir" >&2
+  printf 'changelog_check: base=%s current=%s\n' "$base_semver" "$current_semver" >&2
+  printf 'changelog_check: changed files:\n' >&2
+  printf '%s\n' "$changed_files" | sed 's/^/  /' >&2
+  fail "bump $template_path SemanticVersion and keep the top $changelog_path entry in sync, or use the 'skip changelog' label"
+fi
+
+printf 'changelog_check: %s passed\n' "$package_dir"

--- a/scripts/changelog_check.sh
+++ b/scripts/changelog_check.sh
@@ -96,7 +96,7 @@ if [[ "$has_non_changelog_changes" -eq 1 && -n "$base_semver" ]] && ! semver_gt 
   printf 'changelog_check: base=%s current=%s\n' "$base_semver" "$current_semver" >&2
   printf 'changelog_check: changed files:\n' >&2
   printf '%s\n' "$changed_files" | sed 's/^/  /' >&2
-  fail "bump $template_path SemanticVersion and keep the top $changelog_path entry in sync, or use the 'skip changelog' label"
+  fail "bump $template_path SemanticVersion and keep the top $changelog_path entry in sync, or use the 'skip-changelog' label"
 fi
 
 printf 'changelog_check: %s passed\n' "$package_dir"

--- a/scripts/changelog_release_notes.sh
+++ b/scripts/changelog_release_notes.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+package_dir="${1:-}"
+requested_version="${2:-}"
+
+fail() {
+  echo "changelog_release_notes: $*" >&2
+  exit 1
+}
+
+extract_semver_from_stream() {
+  sed -n 's/^[[:space:]]*SemanticVersion:[[:space:]]*//p' \
+    | head -n1 \
+    | tr -d '"\r' \
+    | xargs
+}
+
+if [[ -z "$package_dir" ]]; then
+  fail "usage: scripts/changelog_release_notes.sh <src/package-dir> [version]"
+fi
+
+package_dir="${package_dir#./}"
+package_dir="${package_dir%/}"
+template_path="$package_dir/template.yaml"
+changelog_path="$package_dir/CHANGELOG.md"
+
+[[ -f "$template_path" ]] || fail "missing template file: $template_path"
+[[ -f "$changelog_path" ]] || fail "missing changelog file: $changelog_path"
+
+version="$requested_version"
+if [[ -z "$version" ]]; then
+  version="$(extract_semver_from_stream < "$template_path")"
+fi
+
+[[ -n "$version" ]] || fail "could not determine SemanticVersion for $package_dir"
+
+section="$(
+  awk -v version="$version" '
+    BEGIN {
+      target = "## [" version "] - "
+      in_section = 0
+      printed = 0
+    }
+    index($0, target) == 1 {
+      in_section = 1
+    }
+    in_section {
+      if (printed && /^## \[/) {
+        exit
+      }
+      print
+      printed = 1
+    }
+  ' "$changelog_path"
+)"
+
+[[ -n "$section" ]] || fail "no changelog section found in $changelog_path for version $version"
+
+printf '%s\n' "$section"

--- a/scripts/release_publish_preflight.sh
+++ b/scripts/release_publish_preflight.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tag_ref="${1:-}"
+master_ref="${2:-origin/master}"
+commit_ish="${3:-HEAD}"
+
+fail() {
+  echo "release_publish_preflight: $*" >&2
+  exit 1
+}
+
+extract_semver_from_stream() {
+  sed -n 's/^[[:space:]]*SemanticVersion:[[:space:]]*//p' \
+    | head -n1 \
+    | tr -d '"\r' \
+    | xargs
+}
+
+extract_application_name() {
+  local template_path="$1"
+
+  awk '
+    /^[[:space:]]{2}AWS::ServerlessRepo::Application:/ {
+      in_app_block = 1
+      next
+    }
+    in_app_block && /^[[:space:]]{2}[A-Za-z0-9:".-]+:/ {
+      exit
+    }
+    in_app_block && /^[[:space:]]{4}Name:/ {
+      sub(/^[[:space:]]*Name:[[:space:]]*/, "")
+      gsub(/["\r]/, "")
+      print
+      exit
+    }
+  ' "$template_path" | xargs
+}
+
+if [[ -z "$tag_ref" ]]; then
+  fail "usage: scripts/release_publish_preflight.sh <tag-or-ref> [master-ref] [commit-ish]"
+fi
+
+while IFS='=' read -r key value; do
+  [[ -n "$key" ]] || continue
+  case "$key" in
+    trigger_tag) trigger_tag="$value" ;;
+    package) package="$value" ;;
+    version) version="$value" ;;
+    canonical_tag) canonical_tag="$value" ;;
+    tag_variant) tag_variant="$value" ;;
+  esac
+done < <(bash scripts/release_tag_resolve.sh "$tag_ref")
+
+[[ -n "${package:-}" ]] || fail "could not resolve package from tag '$tag_ref'"
+[[ -n "${version:-}" ]] || fail "could not resolve version from tag '$tag_ref'"
+[[ -n "${trigger_tag:-}" ]] || fail "could not resolve trigger tag from '$tag_ref'"
+[[ -n "${canonical_tag:-}" ]] || fail "could not resolve canonical tag from '$tag_ref'"
+[[ -n "${tag_variant:-}" ]] || fail "could not resolve tag variant from '$tag_ref'"
+
+package_dir="src/${package}"
+template_path="${package_dir}/template.yaml"
+changelog_path="${package_dir}/CHANGELOG.md"
+
+git rev-parse --verify "$commit_ish" >/dev/null 2>&1 || fail "commit not found: $commit_ish"
+git rev-parse --verify "$master_ref" >/dev/null 2>&1 || fail "master ref not found: $master_ref"
+
+commit_sha="$(git rev-parse "$commit_ish")"
+master_sha="$(git rev-parse "$master_ref")"
+git merge-base --is-ancestor "$commit_sha" "$master_sha" \
+  || fail "tagged commit $commit_sha is not reachable from $master_ref"
+
+[[ -f "$template_path" ]] || fail "missing template file: $template_path"
+[[ -f "$changelog_path" ]] || fail "missing changelog file: $changelog_path"
+
+semantic_version="$(extract_semver_from_stream < "$template_path")"
+[[ -n "$semantic_version" ]] || fail "could not read SemanticVersion from $template_path"
+[[ "$semantic_version" == "$version" ]] \
+  || fail "tag version $version does not match $template_path SemanticVersion $semantic_version"
+
+application_name="$(extract_application_name "$template_path")"
+[[ -n "$application_name" ]] || fail "could not read AWS::ServerlessRepo::Application.Name from $template_path"
+
+bash scripts/changelog_release_notes.sh "$package_dir" "$version" >/dev/null
+
+printf 'trigger_tag=%s\n' "$trigger_tag"
+printf 'canonical_tag=%s\n' "$canonical_tag"
+printf 'tag_variant=%s\n' "$tag_variant"
+printf 'package=%s\n' "$package"
+printf 'package_dir=%s\n' "$package_dir"
+printf 'version=%s\n' "$version"
+printf 'template_path=%s\n' "$template_path"
+printf 'changelog_path=%s\n' "$changelog_path"
+printf 'application_name=%s\n' "$application_name"
+printf 'semantic_version=%s\n' "$semantic_version"
+printf 'commit_sha=%s\n' "$commit_sha"
+printf 'master_ref=%s\n' "$master_ref"
+printf 'master_sha=%s\n' "$master_sha"

--- a/scripts/release_publish_preflight_test.sh
+++ b/scripts/release_publish_preflight_test.sh
@@ -21,8 +21,34 @@ assert_eq() {
   [[ "$actual" == "$expected" ]] || fail "$message: expected '$expected', got '$actual'"
 }
 
+extract_semver() {
+  local template_path="$1"
+
+  sed -n 's/^[[:space:]]*SemanticVersion:[[:space:]]*//p' "$template_path" \
+    | head -n1 \
+    | tr -d '"\r' \
+    | xargs
+}
+
+bump_patch_version() {
+  local version="$1"
+  local major minor patch
+
+  IFS=. read -r major minor patch <<< "$version"
+  [[ -n "$major" && -n "$minor" && -n "$patch" ]] || fail "invalid semantic version '$version'"
+
+  printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))"
+}
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+
+resource_metadata_version="$(extract_semver src/resource-metadata/template.yaml)"
+[[ -n "$resource_metadata_version" ]] || fail "could not extract resource-metadata SemanticVersion"
+
+resource_metadata_tag="resource-metadata-v${resource_metadata_version}"
+resource_metadata_alias_tag="resource-metadata-${resource_metadata_version}"
+resource_metadata_mismatch_tag="resource-metadata-v$(bump_patch_version "$resource_metadata_version")"
 
 canonical_output="$(bash scripts/release_tag_resolve.sh refs/tags/resource-metadata-v1.2.12)"
 assert_eq "resource-metadata" "$(printf '%s\n' "$canonical_output" | get_value package)" "canonical tag package"
@@ -40,20 +66,20 @@ if bash scripts/release_tag_resolve.sh v1.2.3 >/dev/null 2>&1; then
   fail "expected invalid repo-wide tag to be rejected"
 fi
 
-preflight_output="$(bash scripts/release_publish_preflight.sh resource-metadata-v1.2.12 HEAD HEAD)"
+preflight_output="$(bash scripts/release_publish_preflight.sh "$resource_metadata_tag" HEAD HEAD)"
 assert_eq "Coralogix-Resource-Metadata" "$(printf '%s\n' "$preflight_output" | get_value application_name)" "preflight application name"
-assert_eq "resource-metadata-v1.2.12" "$(printf '%s\n' "$preflight_output" | get_value canonical_tag)" "preflight canonical tag"
-assert_eq "1.2.12" "$(printf '%s\n' "$preflight_output" | get_value semantic_version)" "preflight semantic version"
+assert_eq "$resource_metadata_tag" "$(printf '%s\n' "$preflight_output" | get_value canonical_tag)" "preflight canonical tag"
+assert_eq "$resource_metadata_version" "$(printf '%s\n' "$preflight_output" | get_value semantic_version)" "preflight semantic version"
 
-alias_preflight_output="$(bash scripts/release_publish_preflight.sh lambda-secretLayer-1.0.3 HEAD HEAD)"
-assert_eq "lambda-secretLayer-v1.0.3" "$(printf '%s\n' "$alias_preflight_output" | get_value canonical_tag)" "alias preflight canonical tag"
+alias_preflight_output="$(bash scripts/release_publish_preflight.sh "$resource_metadata_alias_tag" HEAD HEAD)"
+assert_eq "$resource_metadata_tag" "$(printf '%s\n' "$alias_preflight_output" | get_value canonical_tag)" "alias preflight canonical tag"
 assert_eq "alias" "$(printf '%s\n' "$alias_preflight_output" | get_value tag_variant)" "alias preflight variant"
 
-if bash scripts/release_publish_preflight.sh resource-metadata-v1.2.12 HEAD^ HEAD >/dev/null 2>&1; then
+if bash scripts/release_publish_preflight.sh "$resource_metadata_tag" HEAD^ HEAD >/dev/null 2>&1; then
   fail "expected non-master ancestry check to fail"
 fi
 
-if bash scripts/release_publish_preflight.sh resource-metadata-v9.9.9 HEAD HEAD >/dev/null 2>&1; then
+if bash scripts/release_publish_preflight.sh "$resource_metadata_mismatch_tag" HEAD HEAD >/dev/null 2>&1; then
   fail "expected mismatched SemanticVersion check to fail"
 fi
 

--- a/scripts/release_publish_preflight_test.sh
+++ b/scripts/release_publish_preflight_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  echo "release_publish_preflight_test: $*" >&2
+  exit 1
+}
+
+get_value() {
+  local key="$1"
+
+  awk -F= -v key="$key" '$1 == key { print substr($0, length($1) + 2); exit }'
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  [[ "$actual" == "$expected" ]] || fail "$message: expected '$expected', got '$actual'"
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+canonical_output="$(bash scripts/release_tag_resolve.sh refs/tags/resource-metadata-v1.2.12)"
+assert_eq "resource-metadata" "$(printf '%s\n' "$canonical_output" | get_value package)" "canonical tag package"
+assert_eq "1.2.12" "$(printf '%s\n' "$canonical_output" | get_value version)" "canonical tag version"
+assert_eq "resource-metadata-v1.2.12" "$(printf '%s\n' "$canonical_output" | get_value canonical_tag)" "canonical tag identity"
+assert_eq "canonical" "$(printf '%s\n' "$canonical_output" | get_value tag_variant)" "canonical tag variant"
+
+alias_output="$(bash scripts/release_tag_resolve.sh lambda-secretLayer-1.0.3)"
+assert_eq "lambda-secretLayer" "$(printf '%s\n' "$alias_output" | get_value package)" "alias tag package"
+assert_eq "1.0.3" "$(printf '%s\n' "$alias_output" | get_value version)" "alias tag version"
+assert_eq "lambda-secretLayer-v1.0.3" "$(printf '%s\n' "$alias_output" | get_value canonical_tag)" "alias canonicalization"
+assert_eq "alias" "$(printf '%s\n' "$alias_output" | get_value tag_variant)" "alias tag variant"
+
+if bash scripts/release_tag_resolve.sh v1.2.3 >/dev/null 2>&1; then
+  fail "expected invalid repo-wide tag to be rejected"
+fi
+
+preflight_output="$(bash scripts/release_publish_preflight.sh resource-metadata-v1.2.12 HEAD HEAD)"
+assert_eq "Coralogix-Resource-Metadata" "$(printf '%s\n' "$preflight_output" | get_value application_name)" "preflight application name"
+assert_eq "resource-metadata-v1.2.12" "$(printf '%s\n' "$preflight_output" | get_value canonical_tag)" "preflight canonical tag"
+assert_eq "1.2.12" "$(printf '%s\n' "$preflight_output" | get_value semantic_version)" "preflight semantic version"
+
+alias_preflight_output="$(bash scripts/release_publish_preflight.sh lambda-secretLayer-1.0.3 HEAD HEAD)"
+assert_eq "lambda-secretLayer-v1.0.3" "$(printf '%s\n' "$alias_preflight_output" | get_value canonical_tag)" "alias preflight canonical tag"
+assert_eq "alias" "$(printf '%s\n' "$alias_preflight_output" | get_value tag_variant)" "alias preflight variant"
+
+if bash scripts/release_publish_preflight.sh resource-metadata-v1.2.12 HEAD^ HEAD >/dev/null 2>&1; then
+  fail "expected non-master ancestry check to fail"
+fi
+
+if bash scripts/release_publish_preflight.sh resource-metadata-v9.9.9 HEAD HEAD >/dev/null 2>&1; then
+  fail "expected mismatched SemanticVersion check to fail"
+fi
+
+if bash scripts/release_publish_preflight.sh does-not-exist-v1.2.3 HEAD HEAD >/dev/null 2>&1; then
+  fail "expected missing package check to fail"
+fi
+
+echo "release_publish_preflight_test: all checks passed"

--- a/scripts/release_tag_resolve.sh
+++ b/scripts/release_tag_resolve.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tag_ref="${1:-}"
+
+fail() {
+  echo "release_tag_resolve: $*" >&2
+  exit 1
+}
+
+if [[ -z "$tag_ref" ]]; then
+  fail "usage: scripts/release_tag_resolve.sh <tag-or-ref>"
+fi
+
+trigger_tag="${tag_ref#refs/tags/}"
+
+canonical_pattern='^([A-Za-z0-9][A-Za-z0-9-]*)-v([0-9]+\.[0-9]+\.[0-9]+)$'
+alias_pattern='^([A-Za-z0-9][A-Za-z0-9-]*)-([0-9]+\.[0-9]+\.[0-9]+)$'
+
+if [[ "$trigger_tag" =~ $canonical_pattern ]]; then
+  package="${BASH_REMATCH[1]}"
+  version="${BASH_REMATCH[2]}"
+  tag_variant="canonical"
+elif [[ "$trigger_tag" =~ $alias_pattern ]]; then
+  package="${BASH_REMATCH[1]}"
+  version="${BASH_REMATCH[2]}"
+  tag_variant="alias"
+else
+  fail "tag '$trigger_tag' must match <package>-v<X.Y.Z> or <package>-<X.Y.Z>"
+fi
+
+canonical_tag="${package}-v${version}"
+
+printf 'trigger_tag=%s\n' "$trigger_tag"
+printf 'package=%s\n' "$package"
+printf 'version=%s\n' "$version"
+printf 'canonical_tag=%s\n' "$canonical_tag"
+printf 'tag_variant=%s\n' "$tag_variant"

--- a/src/cloudwatch-metrics/CHANGELOG.md
+++ b/src/cloudwatch-metrics/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-## cloudwatch-metrics
-<!-- To add a new entry write: -->
-<!-- ### version / full date -->
-<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+All notable changes to this project will be documented in this file.
+This format is based on Keep a Changelog.
+
+## [1.0.7] - 2023-07-30
+### Added
+- Add US2 region support.
+
+## [1.0.6] - 2023-03-27
+### Added
+- Add ingress support for the integration.
+
+## [1.0.5] - 2023-03-23
+### Changed
+- Align the published application version metadata.
+
+## [1.0.4] - 2023-03-23
+### Changed
+- Remove UUID validation from the private key parameter.
+
+## [1.0.3] - 2022-09-13
+### Changed
+- Upgrade the runtime to Node.js 16.x.
+
+## [1.0.2] - 2022-09-12
+### Changed
+- Refresh the published package with the updated Node.js runtime.

--- a/src/coralogix-reporter/CHANGELOG.md
+++ b/src/coralogix-reporter/CHANGELOG.md
@@ -1,24 +1,33 @@
 # Changelog
 
-## coralogix-reporter
+All notable changes to this project will be documented in this file.
+This format is based on Keep a Changelog.
 
-### 3.0.0 / 13.03.2025
-* [Fix] Rewrite the function from callback to async/await. This will resolve a critical issue, where the Lambda exits before the e-mail is being sent
-* [Update] Replace API endpoints + CX region names to the new ones
-* [Update] Rewrite the API logic to fit the new OpenSearch endpoints – default var + authorization header
-* [Feature] Improve templating by parsing the API response's JSON and exit the function on empty result of templating
-* [Fix] Add more logs and error handling to make the function easier to troubleshoot in case when it's not working as expected
-* [Feature] Rake the search index configurable
-* [Fix] Remove the unused IAM policy from the SAM template
-* [Update] Upgrade nodejs from 20.x to 22.x
-* [Update] Upgrade dependencies
+## [3.0.0] - 2025-03-13
+### Added
+- Parse the OpenSearch JSON response in the templating flow and fail fast when the template result is empty.
+- Make the search index configurable.
 
-### 2.0.2 / 1.03.2024
-* [Fix] Add semantic versioning
+### Changed
+- Replace the API endpoints and Coralogix region names with the current ones.
+- Update the OpenSearch request flow to use the new endpoints, default variable handling, and authorization header.
+- Upgrade the runtime from Node.js 20.x to 22.x.
+- Upgrade dependencies.
 
-### 2.0.1 / 1.03.2024
-* [Fix] Add SES sendmail policy to lambda function
+### Fixed
+- Rewrite the function from callbacks to async/await so the Lambda does not exit before the email is sent.
+- Add more logs and error handling to simplify troubleshooting.
+- Remove the unused IAM policy from the SAM template.
 
-### 2.0.0 / 12.12.2023
-* [Update] moved from elasticsearch to opensearch, namechange to coralogix-reporter
-* [Update] upgrade nodejs from 16.x to 20.x
+## [2.0.2] - 2024-03-01
+### Fixed
+- Add semantic versioning metadata.
+
+## [2.0.1] - 2024-03-01
+### Fixed
+- Add the SES `sendmail` policy to the Lambda function.
+
+## [2.0.0] - 2023-12-13
+### Changed
+- Move from Elasticsearch to OpenSearch and rename the package to `coralogix-reporter`.
+- Upgrade the runtime from Node.js 16.x to 20.x.

--- a/src/coralogix-reporter/CHANGELOG.md
+++ b/src/coralogix-reporter/CHANGELOG.md
@@ -27,7 +27,7 @@ This format is based on Keep a Changelog.
 ### Fixed
 - Add the SES `sendmail` policy to the Lambda function.
 
-## [2.0.0] - 2023-12-13
+## [2.0.0] - 2023-12-12
 ### Changed
 - Move from Elasticsearch to OpenSearch and rename the package to `coralogix-reporter`.
 - Upgrade the runtime from Node.js 16.x to 20.x.

--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -1,62 +1,60 @@
 # Changelog
 
-## lambda-manager
+All notable changes to this project will be documented in this file.
+This format is based on Keep a Changelog.
 
-## 2.0.10  / 23-06-2025
-###  💡 Code Enhancements 💡
-- Remove duplication of code
-- Add a description for each function
-- Change the logging format and remove unnecessary logs
-- improve lambda run time
+## [2.0.10] - 2025-06-23
+### Changed
+- Remove duplicated code.
+- Add a description for each function.
+- Change the logging format and remove unnecessary logs.
+- Improve Lambda runtime behavior.
 
-## 2.0.9  / 11-05-2025
-###  💡 Enhancements 💡
-- Add new parameter AddPermissionsToAllLogGroups. When set to true, grants subscription permissions to the destination for all current and future log groups using a wildcard.
+## [2.0.9] - 2025-05-11
+### Added
+- Add the `AddPermissionsToAllLogGroups` parameter to grant subscription permissions to the destination for all current and future log groups using a wildcard.
 
-## 2.0.8  / 30-04-2025
-###  💡 Enhancements 💡
-- Add new parameter DisableAddPermission. Used when a custom Permission Policy was created.
+## [2.0.8] - 2025-04-30
+### Added
+- Add the `DisableAddPermission` parameter for environments that use a custom permission policy.
 
-## 2.0.7  / 20-04-2025
-### 🧰 Bug fixes 🧰
-- Add a check if the log group is a standard log group, and if not, it will be excluded.
+## [2.0.7] - 2025-04-20
+### Fixed
+- Exclude non-standard log groups from processing.
 
-## 2.0.6  / 15-04-2025
-### 🧰 Bug fixes 🧰
-- Remove from the default value of RegexPattern the backslash.
-- Update the lambda code so it will be compatible with requests from Terraform.
+## [2.0.6] - 2025-04-15
+### Fixed
+- Remove the backslash from the default `RegexPattern` value.
+- Update the Lambda code to stay compatible with Terraform-triggered requests.
 
-## 2.0.5  / 17-02-2025
-### 🧰 Bug fixes 🧰
-- Remove wildcard from the lambda permission policy.
-- Update lambda name to in format {{stack_name}}-LambdaFunction.
+## [2.0.5] - 2025-02-17
+### Fixed
+- Remove the wildcard from the Lambda permission policy.
+- Update the Lambda name format to `${stack_name}-LambdaFunction`.
 
-## 2.0.4  / 1-07-2024
-### 🧰 Bug fixes 🧰
-- Add config to boto3, so the lambda could handle ThrottlingException, update error handling in the lambda.
+## [2.0.4] - 2024-07-01
+### Fixed
+- Add boto3 configuration so the Lambda can handle `ThrottlingException`.
+- Improve Lambda error handling.
 
-## 2.0.3  / 26-06-2024
-### 💡 Enhancements 💡
-- Add a new parameter LogGroupPermissionPreFix, when defined the lambda will not create permission for each log group, but 1 permission for the prefix defined in the parameter.
+## [2.0.3] - 2024-06-26
+### Added
+- Add the `LogGroupPermissionPreFix` parameter so one permission can cover all matching log groups under a configured prefix.
 
-## 2.0.2  / 24-06-2024
-### 💡 Enhancements 💡
-- Update the lambda to trigger on creation if ScanOldLogGroups is set to true
+## [2.0.2] - 2024-06-24
+### Added
+- Trigger the Lambda on stack creation when `ScanOldLogGroups` is set to `true`.
 
-## 2.0.1  / 04-2-2024
-### 💡 Enhancements 💡
-- Update lambda code so it will not require the allow all policy
+## [2.0.1] - 2024-02-04
+### Changed
+- Update the Lambda code so it no longer requires the allow-all policy.
 
-## 2.0.0 🎉 / 02-20-2024
-### 🛑 Breaking changes 🛑
-- New CloudFormation Template does not deploy firehose stream as part of the deployment.
-- New CloudFormation Temaplate does not create permissions for destination, check README.
-- Environment Variable names changed.
+## [2.0.0] - 2024-02-20
+### Added
+- Support Lambda as a destination.
+- Scan existing log groups and process them.
 
-### 🚀 New components 🚀
-- Supports Lambda as a Destination
-- scan all loggroups and process them.
-
-<!-- To add a new entry write: -->
-<!-- ### version / full date -->
-<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+### Changed
+- Stop deploying the Firehose stream as part of the CloudFormation template.
+- Stop creating destination permissions automatically in the CloudFormation template.
+- Rename environment variables for the new deployment model.

--- a/src/lambda-secretLayer/CHANGELOG.md
+++ b/src/lambda-secretLayer/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
-## lambda-secretLayer
+All notable changes to this project will be documented in this file.
+This format is based on Keep a Changelog.
 
-### 0.0.3 / 25.8.2024
-* [update] Allow the layer to run in nodejs20 applications.
+## [1.0.3] - 2024-08-25
+### Changed
+- Allow the layer to run in Node.js 20 applications by using the Node.js 18-compatible code path.
 
-### 0.0.2 / 1.10.2023
-* [Change] Change SSM option in the integration to SM - Secret Manager.
+## [1.0.2] - 2023-10-02
+### Changed
+- Switch the integration from the SSM option to AWS Secrets Manager terminology and behavior.
 
-### version 0.0.1 / 15.8.2023
-* [update] Add an option to use an existing secret instead of creating a new one with SSM 
+## [1.0.1] - 2023-08-16
+### Added
+- Allow using an existing secret instead of creating one automatically.
+
+## [1.0.0] - 2023-03-08
+### Added
+- Introduce the secret layer for safe keeping of the Coralogix data API key.

--- a/src/lambda-secretLayer/CHANGELOG.md
+++ b/src/lambda-secretLayer/CHANGELOG.md
@@ -7,11 +7,11 @@ This format is based on Keep a Changelog.
 ### Changed
 - Allow the layer to run in Node.js 20 applications by using the Node.js 18-compatible code path.
 
-## [1.0.2] - 2023-10-02
+## [1.0.2] - 2023-10-01
 ### Changed
 - Switch the integration from the SSM option to AWS Secrets Manager terminology and behavior.
 
-## [1.0.1] - 2023-08-16
+## [1.0.1] - 2023-08-15
 ### Added
 - Allow using an existing secret instead of creating one automatically.
 

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -3,14 +3,15 @@
 All notable changes to this project will be documented in this file.
 This format is based on Keep a Changelog.
 
-## [0.3.2] - 2026-02-20
+## [0.3.2] - 2025-02-20
 ### Added
 - Assume a cross-account IAM role when querying an AWS Config aggregator in a different account via the `ConfigCrossAccountRole` parameter.
 
+## [0.3.1] - 2025-05-05
 ### Fixed
 - Mention `crossaccount.js` in `package.json` so it is included in the build output.
 
-## [0.3.0] - 2025-05-05
+## [0.3.0] - 2025-04-30
 ### Added
 - Support cross-account collection through both AWS Config and static account lists.
 - Enable cross-account EventBridge event reception through the SQS queue.

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -1,39 +1,51 @@
 # Changelog
 
-## resource-metadata-sqs
+All notable changes to this project will be documented in this file.
+This format is based on Keep a Changelog.
 
-### 0.3.2 / 20.02.2025
-* [Feature] Assume cross-account IAM role when querying AWS Config aggregator in a different account (`ConfigCrossAccountRole` parameter)
+## [0.3.2] - 2026-02-20
+### Added
+- Assume a cross-account IAM role when querying an AWS Config aggregator in a different account via the `ConfigCrossAccountRole` parameter.
 
-### 0.3.1 / 05.05.2025
-* [Fix] Mention crossaccount.js in package.json to make it a part of the build
+### Fixed
+- Mention `crossaccount.js` in `package.json` so it is included in the build output.
 
-### 0.3.0 / 30.04.2025
-* [Feature] Cross-account collection has multiple options now: AWS Config and Static Account List
-* [Feature] Enable cross-account Eventbridge events reception by SQS queue
-* [Feature] Filter functions by telemetry-exporter layer
-* [Update] Split StaticIAM configuration between `CROSSACCOUNT_IAM_ACCOUNTIDS` and `CROSSACCOUNT_IAM_ROLE_NAME` env vars
-* [Fix] Get rid of GetFunctionCommand to avoid security vulnerability related to this command (i.e. link to the source code in the command output)
+## [0.3.0] - 2025-05-05
+### Added
+- Support cross-account collection through both AWS Config and static account lists.
+- Enable cross-account EventBridge event reception through the SQS queue.
+- Filter functions by the telemetry-exporter layer.
 
-### 0.2.0 / 02.04.2025
-* [Feature] CDS-1996 Add support for multiple regions and accounts
-* [Fix] Align line endings in js files to always add with semicolon (`;`)
+### Changed
+- Split StaticIAM configuration between the `CROSSACCOUNT_IAM_ACCOUNTIDS` and `CROSSACCOUNT_IAM_ROLE_NAME` environment variables.
 
-### 0.1.4 / 19.02.2025
-* [Fix] CDS-1876 Reduce EC2 batch size by half as default (50 --> 25) and let the user configure the chunk size
+### Fixed
+- Stop using `GetFunctionCommand` in the collection flow to avoid exposing source-code links in command output.
 
-### 0.1.3 / 17.02.2025
-* [Fix] CDS-1876 rewrite batch collection of EC2 instances to avoid exceeding the SQS message size limit
+## [0.2.0] - 2025-04-02
+### Added
+- Add support for collecting metadata across multiple regions and accounts.
 
-### 0.1.2 / 04.02.2025
-* [Fix] Adjust CloudTrail S3 bucket name to fit the character limit (<=63 characters)
+### Fixed
+- Align JavaScript line endings so files consistently end with semicolons.
 
-### 0.1.1 / 31.01.2025
-* [Fix] Remove non-existent function from SAM template and hardcode message retention period to 1 hour instead of using the resource ttl.
-* [Fix] Update GitHub Actions publish step to store multi-function SAM template.
+## [0.1.4] - 2025-02-19
+### Fixed
+- Reduce the default EC2 batch size from 50 to 25 and make the chunk size configurable.
 
-### 0.1.0 / 28.01.2025
-* First version
-<!-- To add a new entry write: -->
-<!-- ### version / full date -->
-<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+## [0.1.3] - 2025-02-17
+### Fixed
+- Rewrite EC2 batch collection to avoid exceeding the SQS message size limit.
+
+## [0.1.2] - 2025-02-04
+### Fixed
+- Adjust the CloudTrail S3 bucket name so it stays within the 63-character limit.
+
+## [0.1.1] - 2025-01-31
+### Fixed
+- Remove the non-existent function from the SAM template and hardcode the message retention period to one hour instead of using the resource TTL.
+- Update the GitHub Actions publish step to store the multi-function SAM template.
+
+## [0.1.0] - 2025-01-28
+### Added
+- Initial release.

--- a/src/resource-metadata/CHANGELOG.md
+++ b/src/resource-metadata/CHANGELOG.md
@@ -38,10 +38,10 @@ This format is based on Keep a Changelog.
 ### Added
 - Add filtering for Lambda functions.
 
-## [0.0.2] - 2023-10-02
+## [0.0.2] - 2023-10-01
 ### Changed
 - Switch the integration from the SSM option to AWS Secrets Manager terminology and behavior.
 
-## [0.0.1] - 2023-08-16
+## [0.0.1] - 2023-08-15
 ### Added
 - Allow using an existing secret instead of creating one automatically and remove the `SsmEnabled` parameter.

--- a/src/resource-metadata/CHANGELOG.md
+++ b/src/resource-metadata/CHANGELOG.md
@@ -1,37 +1,47 @@
 # Changelog
 
-## resource-metadata
+All notable changes to this project will be documented in this file.
+This format is based on Keep a Changelog.
 
-### 1.2.12 / 04.12.2025
-* [Update] Update Node.js version to 22.x
+## [1.2.12] - 2025-12-04
+### Changed
+- Update the Node.js runtime to 22.x.
 
-### 1.2.11 / 15.10.2024
-* [Fix] Fix typo in the conditioning to exclude ec2/lambdas resources.
+## [1.2.11] - 2024-10-15
+### Fixed
+- Fix the condition that excludes EC2 and Lambda resources.
 
-### 1.2.10 / 09.10.2024
-* [Update] Add resource type filter to exclude either lambda and ec2 resources.
-* [Update] Add AP3 region to the list of regions.
+## [1.2.10] - 2024-10-09
+### Added
+- Add AP3 to the supported region list.
 
-### 1.2.9 / 21.05.2024
-* [Update] Align Regions names with other integration .i.e EU1,EU2...
+### Changed
+- Add a resource-type filter so either Lambda or EC2 resources can be excluded.
 
-### 1.2.8 / 8.02.2024
-* [Update] update dependencies and remove jest and babel
+## [1.2.9] - 2024-05-21
+### Changed
+- Align region names with the rest of the integrations, for example `EU1` and `EU2`.
 
-### 1.2.7 / 13.12.2023
-* [Fix] Correct conversion of tags to attributes
+## [1.2.8] - 2024-02-08
+### Changed
+- Update dependencies and remove Jest and Babel.
 
-### 1.2.6 / 13.12.2023
-* [Change] The function will not fail when it can't collect metadata of some lambda function
+## [1.2.7] - 2023-12-13
+### Fixed
+- Correct tag-to-attribute conversion.
 
-### 1.2.5 / 7.12.2023
-* [Update] Add filtering of Lambda functions.
+## [1.2.6] - 2023-12-13
+### Changed
+- Keep the function running even when it cannot collect metadata for some Lambda functions.
 
-### 0.0.2 / 1.10.2023
-* [Change] Change SSM option in the integration to SM - Secret Manager.
+## [1.2.5] - 2023-12-07
+### Added
+- Add filtering for Lambda functions.
 
-### 0.0.1 / 15.8.2023
-* [update] Add an option to use an existing secret instead of creating a new one with SSM, and remove the SsmEnabled parameter.
-<!-- To add a new entry write: -->
-<!-- ### version / full date -->
-<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+## [0.0.2] - 2023-10-02
+### Changed
+- Switch the integration from the SSM option to AWS Secrets Manager terminology and behavior.
+
+## [0.0.1] - 2023-08-16
+### Added
+- Allow using an existing secret instead of creating one automatically and remove the `SsmEnabled` parameter.

--- a/src/sf-eventlog/CHANGELOG.md
+++ b/src/sf-eventlog/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Changelog
 
-## sf-eventlog
-### 1.0.3
+All notable changes to this project will be documented in this file.
+This format is based on Keep a Changelog.
 
-* [Bug fix] fix sf update in api.
-<!-- To add a new entry write: -->
-<!-- ### version / full date -->
-<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+## [1.0.3] - 2023-08-09
+### Fixed
+- Fix the Salesforce API update flow.
+
+## [1.0.2] - 2023-07-30
+### Added
+- Add US2 region support.
+
+## [1.0.1] - 2023-03-27
+### Added
+- Add ingress support.
+
+## [1.0.0] - 2022-12-15
+### Added
+- Initial Salesforce event-log integration.


### PR DESCRIPTION
## Summary
- normalize the 7 published lambda `CHANGELOG.md` files and enforce that each top release entry stays aligned with `template.yaml` `SemanticVersion`
- keep PR-time changelog/version guardrails, including allowing changelog-only package diffs without forcing a version bump
- replace merge-time SAR publishing with package-scoped tag-triggered publishing
- accept both `<name>-v<X.Y.Z>` and `<name>-<X.Y.Z>` as publish tags while canonicalizing GitHub Releases to `<name>-v<X.Y.Z>`
- document the release contract in `README.md` and root `AGENTS.md` so maintainers and coding agents follow the same flow

## Release Contract
### Versioning
- For published packages under `src/<name>/`, `Metadata.AWS::ServerlessRepo::Application.SemanticVersion` in `template.yaml` is the single source of truth.
- Bump `SemanticVersion` whenever a published package changes beyond `CHANGELOG.md`.
- Do not reuse a previously published version number. AWS SAR versions are immutable, so a bad publish must be corrected with a new commit and a new version.

### Changelog
- Each published package keeps `src/<name>/CHANGELOG.md`.
- The first release heading must be `## [X.Y.Z] - YYYY-MM-DD`.
- The top changelog version must match `template.yaml` `SemanticVersion`.
- The top release entry must contain at least one bullet.
- Changelog-only edits do not require a `SemanticVersion` bump.
- `skip-changelog` is only for package changes that do not need either a changelog entry or a version bump.

### Publishing
- Merge to `master` does not publish by itself.
- Promotion happens after merge by pushing a package tag on the merged `master` commit you want to release.
- Accepted publish tags are `<name>-v<X.Y.Z>` and `<name>-<X.Y.Z>`.
- Both tag forms publish the same single package version.
- `<name>-v<X.Y.Z>` is the canonical GitHub Release identity.
- If the bare alias tag is pushed first, the workflow backfills the canonical `<name>-v<X.Y.Z>` tag after successful publish and creates the release there.

### Maintainer Flow
1. Merge the package change to `master`.
2. Validate the merged commit you want to promote.
3. Confirm `src/<name>/template.yaml` `SemanticVersion` matches the top `src/<name>/CHANGELOG.md` release.
4. Push either `git tag <name>-v<X.Y.Z>` or `git tag <name>-<X.Y.Z>` on that merged commit.
5. Run `git push origin <tag>` to trigger publishing.

## Historical Note
- Some older changelog sections were reconstructed from git history to satisfy the new versioning contract, so their dates should be treated as best-effort backfill rather than authoritative SAR publication timestamps.
- This especially affects `cloudwatch-metrics` and `sf-eventlog`, whose earlier entries were filled in retroactively, and `lambda-secretLayer`, whose older `0.0.x` history was normalized into the current `1.0.x` line to match the package contract on `master`.

## Verification
- ran `bash -n scripts/changelog_check.sh scripts/changelog_release_notes.sh scripts/release_tag_resolve.sh scripts/release_publish_preflight.sh scripts/release_publish_preflight_test.sh`
- ran `bash scripts/changelog_check.sh` successfully for `cloudwatch-metrics`, `coralogix-reporter`, `lambda-manager`, `lambda-secretLayer`, `resource-metadata`, `resource-metadata-sqs`, and `sf-eventlog`
- ran `bash scripts/release_publish_preflight_test.sh`
- ran `git diff --check`
- PR checks rerun on each branch update; the current branch was green before the latest workflow-only follow-up push
