### PR TITLE
Fix lambda-manager subscriptions when LogGroupClass is omitted

### DIFF
--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This format is based on Keep a Changelog.
 
+## [2.0.12] - 2026-06-15
+### Fixed
+- Match CloudFormation `CreateLogGroup` events when `LogGroupClass` is omitted and the log group still defaults to `STANDARD`.
+- Continue skipping non-standard `INFREQUENT_ACCESS` and `DELIVERY` log groups during create-event processing.
+
 ## [2.0.11] - 2026-06-13
 ### Fixed
 - Ignore failed CloudTrail `CreateLogGroup` events so they do not trigger duplicate subscription work.

--- a/src/lambda-manager/lambda_function.py
+++ b/src/lambda-manager/lambda_function.py
@@ -26,6 +26,8 @@ config = Config(
 cloudwatch_logs = boto3.client('logs', config=config)
 lambda_client = boto3.client('lambda', config=config)
 
+SUPPORTED_LOG_GROUP_CLASS = "STANDARD"
+
 def lambda_handler(event: Dict[str, Any], context) -> None:
     """
     Main Lambda function handler that manages CloudWatch log group subscriptions.
@@ -94,6 +96,9 @@ def lambda_handler(event: Dict[str, Any], context) -> None:
                 return
 
             log_group_to_subscribe = event_detail['requestParameters']['logGroupName']
+
+            if not should_process_log_group_class(event_detail):
+                return
             found_log_group_in_regex_pattern = False
             
             for regex_pattern in regex_pattern_list:
@@ -249,6 +254,21 @@ def should_create_subscription(cloudwatch_logs, log_group_name: str, destination
         return False
 
     return True
+
+def should_process_log_group_class(event_detail: Dict[str, Any]) -> bool:
+    """
+    Allow standard log groups, including events where CloudTrail omits logGroupClass.
+
+    CloudFormation-created log groups default to STANDARD even when the property is
+    not present in requestParameters. Explicit non-standard classes should still be
+    ignored to preserve the existing behavior.
+    """
+    log_group_class = event_detail.get('requestParameters', {}).get('logGroupClass', SUPPORTED_LOG_GROUP_CLASS)
+    if log_group_class == SUPPORTED_LOG_GROUP_CLASS:
+        return True
+
+    logger.info(f"Skipping log group because logGroupClass {log_group_class} is not supported")
+    return False
 
 def add_subscription(
     filter_name: str, 

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -16,7 +16,7 @@ Metadata:
       - cloudwatch
       - lambda
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 2.0.11
+    SemanticVersion: 2.0.12
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -215,6 +215,7 @@ Resources:
                 requestParameters:
                   logGroupClass:
                     - "STANDARD"
+                    - exists: false
             Target:
                 Id: cx-loggroup-target
 

--- a/src/lambda-manager/tests/test_lambda_function.py
+++ b/src/lambda-manager/tests/test_lambda_function.py
@@ -107,7 +107,7 @@ class LambdaManagerCreateLogGroupTests(unittest.TestCase):
         add_permission.assert_not_called()
         add_subscription.assert_not_called()
 
-    def test_new_destination_subscription_still_gets_created(self):
+    def test_event_without_log_group_class_still_gets_subscribed(self):
         event = {"detail": {"requestParameters": {"logGroupName": "/aws/lambda/example"}}}
         self.module.cloudwatch_logs.describe_subscription_filters.return_value = {"subscriptionFilters": []}
 
@@ -124,6 +124,25 @@ class LambdaManagerCreateLogGroupTests(unittest.TestCase):
         )
         add_subscription.assert_called_once()
 
+    def test_non_standard_log_group_class_is_ignored(self):
+        for log_group_class in ("INFREQUENT_ACCESS", "DELIVERY"):
+            event = {
+                "detail": {
+                    "requestParameters": {
+                        "logGroupName": "/aws/lambda/example",
+                        "logGroupClass": log_group_class,
+                    }
+                }
+            }
+
+            with self.subTest(log_group_class=log_group_class):
+                with patch.object(self.module, "add_permission_to_lambda") as add_permission, patch.object(
+                    self.module, "add_subscription"
+                ) as add_subscription:
+                    self.invoke_handler(event)
+
+                add_permission.assert_not_called()
+                add_subscription.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/lambda-manager/tests/test_template.py
+++ b/src/lambda-manager/tests/test_template.py
@@ -1,38 +1,27 @@
+import re
 import unittest
 from pathlib import Path
-
-import yaml
 
 
 TEMPLATE_PATH = Path(__file__).resolve().parents[1] / "template.yaml"
 
 
-class CloudFormationLoader(yaml.SafeLoader):
-    pass
-
-
-def construct_cloudformation_tag(loader, tag_suffix, node):
-    if isinstance(node, yaml.ScalarNode):
-        return loader.construct_scalar(node)
-    if isinstance(node, yaml.SequenceNode):
-        return loader.construct_sequence(node)
-    return loader.construct_mapping(node)
-
-
-CloudFormationLoader.add_multi_constructor("!", construct_cloudformation_tag)
-
-
 class LambdaManagerTemplateTests(unittest.TestCase):
     def test_eventbridge_pattern_matches_standard_or_missing_log_group_class(self):
-        template = yaml.load(TEMPLATE_PATH.read_text(), Loader=CloudFormationLoader)
-        event_pattern = (
-            template["Resources"]["LambdaFunction"]["Properties"]["Events"]["EventBridgeRule"]["Properties"]["Pattern"]
-        )
-        log_group_class_pattern = event_pattern["detail"]["requestParameters"]["logGroupClass"]
+        template = TEMPLATE_PATH.read_text()
+        match = re.search(r"logGroupClass:\n((?:\s+-.*\n)+)", template)
 
-        self.assertIn("STANDARD", log_group_class_pattern)
-        self.assertIn({"exists": False}, log_group_class_pattern)
-        self.assertEqual(2, len(log_group_class_pattern))
+        self.assertIsNotNone(match)
+
+        log_group_class_pattern = [line.strip() for line in match.group(1).splitlines()]
+
+        self.assertEqual(
+            [
+                '- "STANDARD"',
+                "- exists: false",
+            ],
+            log_group_class_pattern,
+        )
 
 
 if __name__ == "__main__":

--- a/src/lambda-manager/tests/test_template.py
+++ b/src/lambda-manager/tests/test_template.py
@@ -1,0 +1,39 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+TEMPLATE_PATH = Path(__file__).resolve().parents[1] / "template.yaml"
+
+
+class CloudFormationLoader(yaml.SafeLoader):
+    pass
+
+
+def construct_cloudformation_tag(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_mapping(node)
+
+
+CloudFormationLoader.add_multi_constructor("!", construct_cloudformation_tag)
+
+
+class LambdaManagerTemplateTests(unittest.TestCase):
+    def test_eventbridge_pattern_matches_standard_or_missing_log_group_class(self):
+        template = yaml.load(TEMPLATE_PATH.read_text(), Loader=CloudFormationLoader)
+        event_pattern = (
+            template["Resources"]["LambdaFunction"]["Properties"]["Events"]["EventBridgeRule"]["Properties"]["Pattern"]
+        )
+        log_group_class_pattern = event_pattern["detail"]["requestParameters"]["logGroupClass"]
+
+        self.assertIn("STANDARD", log_group_class_pattern)
+        self.assertIn({"exists": False}, log_group_class_pattern)
+        self.assertEqual(2, len(log_group_class_pattern))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- match CloudFormation CreateLogGroup events when requestParameters.logGroupClass is omitted
- keep skipping explicit INFREQUENT_ACCESS and DELIVERY log groups
- add handler and template regression tests for the new event shapes

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s src/lambda-manager/tests -p 'test_*.py'
- `aws events test-event-pattern` against the updated template pattern: omitted=true, standard=true, infrequent_access=false, delivery=false
- live regression against terraform-playground fixture `/aws/lambda/tags-testing-lambda` with destination `helper-regression-thqp6z-cloudwatch-forwarder`: omitted class created one subscription and cleanup returned to `[]`; INFREQUENT_ACCESS and DELIVERY created zero subscriptions

Closes #189
