### PR TITLE
feat: add optional SnsKmsKeyArn to encrypt Lambda failure SNS topics

### DIFF
--- a/src/coralogix-reporter/CHANGELOG.md
+++ b/src/coralogix-reporter/CHANGELOG.md
@@ -6,6 +6,8 @@ This format is based on Keep a Changelog.
 ## [3.0.1] - 2026-08-13
 ### Added
 - Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+### Fixed
+- Reuse the SAM OnFailure topic logical ID so existing email subscriptions are not replaced when `SnsKmsKeyArn` is unset.
 
 ## [3.0.0] - 2025-03-13
 ### Added

--- a/src/coralogix-reporter/CHANGELOG.md
+++ b/src/coralogix-reporter/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This format is based on Keep a Changelog.
 
+## [3.0.1] - 2026-08-13
+### Added
+- Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+
 ## [3.0.0] - 2025-03-13
 ### Added
 - Parse the OpenSearch JSON response in the templating flow and fail fast when the template result is empty.

--- a/src/coralogix-reporter/README.md
+++ b/src/coralogix-reporter/README.md
@@ -20,6 +20,7 @@ The API key can be created in your Coralogix account under `Data Flow` -> `API K
 * **Subject** - report email subject line.
 * **RequestTimeout** - the OpenSearch query timeout.
 * **NotificationEmail** - Failure notification email address.
+* **SnsKmsKeyArn** - Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`.
 
 ## Usage
 

--- a/src/coralogix-reporter/README.md
+++ b/src/coralogix-reporter/README.md
@@ -20,7 +20,7 @@ The API key can be created in your Coralogix account under `Data Flow` -> `API K
 * **Subject** - report email subject line.
 * **RequestTimeout** - the OpenSearch query timeout.
 * **NotificationEmail** - Failure notification email address.
-* **SnsKmsKeyArn** - Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`.
+* **SnsKmsKeyArn** - Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`.
 
 ## Usage
 

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -134,7 +134,7 @@ Conditions:
   IsScheduleEnabled: !Not [!Equals [!Ref ScheduleEnable, 'false']] 
     
 Resources:
-  FailureNotificationTopic:
+  LambdaFunctionEventInvokeConfigOnFailureTopic:
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: !If
@@ -200,7 +200,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref LambdaFunctionEventInvokeConfigOnFailureTopic
       Events:
         CloudWatchSchedule:
           Type: Schedule
@@ -217,5 +217,4 @@ Resources:
       Protocol: email
       Endpoint:
         Ref: NotificationEmail
-      TopicArn:
-        Ref: FailureNotificationTopic
+      TopicArn: !Ref LambdaFunctionEventInvokeConfigOnFailureTopic

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -111,7 +111,8 @@ Parameters:
     Default: ''
   SnsKmsKeyArn:
     Type: String
-    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Description: Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    AllowedPattern: '^$|^arn:[a-z0-9-]+:kms:[a-z0-9-]+:[0-9]{12}:key/.+$'
     Default: ''
 Mappings:
   CoralogixRegionMap:

--- a/src/coralogix-reporter/template.yaml
+++ b/src/coralogix-reporter/template.yaml
@@ -18,7 +18,7 @@ Metadata:
       - ses
       - email
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 3.0.0
+    SemanticVersion: 3.0.1
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
 Parameters:
   CoralogixRegion:
@@ -109,6 +109,10 @@ Parameters:
     Description: Failure notification email address
     MaxLength: 320
     Default: ''
+  SnsKmsKeyArn:
+    Type: String
+    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Default: ''
 Mappings:
   CoralogixRegionMap:
     EU1:
@@ -125,9 +129,17 @@ Mappings:
       LogUrl: https://api.cx498.coralogix.com/data/os-api
 Conditions:
   IsNotificationEnabled: !Not [!Equals [!Ref NotificationEmail, '']]
+  IsSnsKmsKeySet: !Not [!Equals [!Ref SnsKmsKeyArn, '']]
   IsScheduleEnabled: !Not [!Equals [!Ref ScheduleEnable, 'false']] 
     
 Resources:
+  FailureNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
   LambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -172,10 +184,22 @@ Resources:
                 - 'ses:SendEmail'
                 - 'ses:SendRawEmail'
               Resource: '*'
+        - !If
+          - IsSnsKmsKeySet
+          - Version: '2012-10-17'
+            Statement:
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+          - !Ref AWS::NoValue
       EventInvokeConfig:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Events:
         CloudWatchSchedule:
           Type: Schedule
@@ -193,4 +217,4 @@ Resources:
       Endpoint:
         Ref: NotificationEmail
       TopicArn:
-        Ref: LambdaFunction.DestinationTopic
+        Ref: FailureNotificationTopic

--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This format is based on Keep a Changelog.
 
+## [2.0.13] - 2026-08-13
+### Added
+- Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+
 ## [2.0.12] - 2026-06-15
 ### Fixed
 - Match CloudFormation `CreateLogGroup` events when `LogGroupClass` is omitted and the log group still defaults to `STANDARD`.

--- a/src/lambda-manager/CHANGELOG.md
+++ b/src/lambda-manager/CHANGELOG.md
@@ -6,6 +6,8 @@ This format is based on Keep a Changelog.
 ## [2.0.13] - 2026-08-13
 ### Added
 - Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+### Fixed
+- Reuse the SAM OnFailure topic logical ID so existing email subscriptions are not replaced when `SnsKmsKeyArn` is unset.
 
 ## [2.0.12] - 2026-06-15
 ### Fixed

--- a/src/lambda-manager/README.md
+++ b/src/lambda-manager/README.md
@@ -19,7 +19,7 @@ Environment variables:
 | FunctionMemorySize | The maximum allocated memory this lambda may consume. The default value is the minimum recommended setting please consult coralogix support before changing. | 1024 |  |
 | FunctionTimeout | The maximum time in seconds the function may be allowed to run. The default value is the minimum recommended setting please consult coralogix support before changing. | 300 |  |
 | NotificationEmail | Failure notification email address | | |
-| SnsKmsKeyArn | Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
+| SnsKmsKeyArn | Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
 
 ## Requirements
 

--- a/src/lambda-manager/README.md
+++ b/src/lambda-manager/README.md
@@ -19,6 +19,7 @@ Environment variables:
 | FunctionMemorySize | The maximum allocated memory this lambda may consume. The default value is the minimum recommended setting please consult coralogix support before changing. | 1024 |  |
 | FunctionTimeout | The maximum time in seconds the function may be allowed to run. The default value is the minimum recommended setting please consult coralogix support before changing. | 300 |  |
 | NotificationEmail | Failure notification email address | | |
+| SnsKmsKeyArn | Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
 
 ## Requirements
 

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -118,7 +118,7 @@ Conditions:
           - Ref: SnsKmsKeyArn
           - ''
 Resources:
-  FailureNotificationTopic:
+  LambdaFunctionEventInvokeConfigOnFailureTopic:
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: !If
@@ -225,7 +225,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref LambdaFunctionEventInvokeConfigOnFailureTopic
       Events:
         EventBridgeRule:
           Type: EventBridgeRule
@@ -260,4 +260,4 @@ Resources:
       Endpoint:
         Ref: NotificationEmail
       TopicArn:
-        Ref: FailureNotificationTopic
+        Ref: LambdaFunctionEventInvokeConfigOnFailureTopic

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -16,7 +16,7 @@ Metadata:
       - cloudwatch
       - lambda
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 2.0.12
+    SemanticVersion: 2.0.13
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -26,6 +26,7 @@ Metadata:
           - LogsFilter
           - RegexPattern
           - NotificationEmail
+          - SnsKmsKeyArn
           - DestinationArn
           - DestinationRole
           - DestinationType
@@ -96,6 +97,10 @@ Parameters:
     Description: Failure notification email address
     MaxLength: 320
     Default: ''
+  SnsKmsKeyArn:
+    Type: String
+    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Default: ''
 Conditions:
   IsDestinationLambda:
     Fn::Equals:
@@ -106,7 +111,19 @@ Conditions:
       - Fn::Equals:
           - Ref: NotificationEmail
           - ''
+  IsSnsKmsKeySet:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: SnsKmsKeyArn
+          - ''
 Resources:
+  FailureNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -194,10 +211,20 @@ Resources:
                 - iam:PassRole
               Resource: 
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/*"
+            - !If
+              - IsSnsKmsKeySet
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+              - !Ref AWS::NoValue
       EventInvokeConfig:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Events:
         EventBridgeRule:
           Type: EventBridgeRule
@@ -232,4 +259,4 @@ Resources:
       Endpoint:
         Ref: NotificationEmail
       TopicArn:
-        Ref: LambdaFunction.DestinationTopic
+        Ref: FailureNotificationTopic

--- a/src/lambda-manager/template.yaml
+++ b/src/lambda-manager/template.yaml
@@ -99,7 +99,8 @@ Parameters:
     Default: ''
   SnsKmsKeyArn:
     Type: String
-    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Description: Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    AllowedPattern: '^$|^arn:[a-z0-9-]+:kms:[a-z0-9-]+:[0-9]{12}:key/.+$'
     Default: ''
 Conditions:
   IsDestinationLambda:

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This format is based on Keep a Changelog.
 
+## [0.3.3] - 2026-08-13
+### Added
+- Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+
 ## [0.3.2] - 2025-02-20
 ### Added
 - Assume a cross-account IAM role when querying an AWS Config aggregator in a different account via the `ConfigCrossAccountRole` parameter.

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -7,7 +7,7 @@ This format is based on Keep a Changelog.
 ### Added
 - Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
 ### Fixed
-- Keep a single email subscription on the shared failure-notification SNS topic.
+- Reuse the SAM OnFailure topic logical IDs so existing email subscriptions are not replaced when `SnsKmsKeyArn` is unset.
 
 ## [0.3.2] - 2025-02-20
 ### Added

--- a/src/resource-metadata-sqs/CHANGELOG.md
+++ b/src/resource-metadata-sqs/CHANGELOG.md
@@ -6,6 +6,8 @@ This format is based on Keep a Changelog.
 ## [0.3.3] - 2026-08-13
 ### Added
 - Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+### Fixed
+- Keep a single email subscription on the shared failure-notification SNS topic.
 
 ## [0.3.2] - 2025-02-20
 ### Added

--- a/src/resource-metadata-sqs/README.md
+++ b/src/resource-metadata-sqs/README.md
@@ -232,6 +232,7 @@ EC2 only:
 | LambdaFunctionExcludeRegexFilter | If specified, only lambda functions with ARNs NOT matching the regex will be included in the collected metadata | | |
 | LambdaFunctionTagFilters | If specified, only lambda functions with tags matching the filters will be included in the collected metadata. Values should follow the JSON syntax for --tag-filters as documented [here](https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options) | | |
 | NotificationEmail | If the lambda fails a notification email will be sent to this address via SNS (requires you have a working SNS, with a validated domain). | | |
+| SnsKmsKeyArn | Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
 | ExcludedEC2ResourceType | Set to true to Excluded EC2 Resource Type | `False` | |
 | ExcludedLambdaResourceType | Set to true to Excluded Resource Type | `False` | |
 | EC2ChunkSize | Number of resources in each EC2 batch (1-40) | 25 | |

--- a/src/resource-metadata-sqs/README.md
+++ b/src/resource-metadata-sqs/README.md
@@ -232,7 +232,7 @@ EC2 only:
 | LambdaFunctionExcludeRegexFilter | If specified, only lambda functions with ARNs NOT matching the regex will be included in the collected metadata | | |
 | LambdaFunctionTagFilters | If specified, only lambda functions with tags matching the filters will be included in the collected metadata. Values should follow the JSON syntax for --tag-filters as documented [here](https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options) | | |
 | NotificationEmail | If the lambda fails a notification email will be sent to this address via SNS (requires you have a working SNS, with a validated domain). | | |
-| SnsKmsKeyArn | Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
+| SnsKmsKeyArn | Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
 | ExcludedEC2ResourceType | Set to true to Excluded EC2 Resource Type | `False` | |
 | ExcludedLambdaResourceType | Set to true to Excluded Resource Type | `False` | |
 | EC2ChunkSize | Number of resources in each EC2 batch (1-40) | 25 | |

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -272,7 +272,8 @@ Parameters:
     Default: ""
   SnsKmsKeyArn:
     Type: String
-    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Description: Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    AllowedPattern: '^$|^arn:[a-z0-9-]+:kms:[a-z0-9-]+:[0-9]{12}:key/.+$'
     Default: ""
   CreateSecret:
     Type: String

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -14,7 +14,7 @@ Metadata:
       - metadata
       - sqs
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.3.2
+    SemanticVersion: 0.3.3
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -50,6 +50,7 @@ Metadata:
           - LambdaFunctionExcludeRegexFilter
           - LambdaFunctionTagFilters
           - NotificationEmail
+          - SnsKmsKeyArn
           - ExcludedEC2ResourceType
           - ExcludedLambdaResourceType
           - EC2ChunkSize
@@ -116,6 +117,8 @@ Metadata:
         default: Maximum SQS Processing Concurrency
       NotificationEmail:
         default: Notification Email
+      SnsKmsKeyArn:
+        default: SNS KMS Key ARN
       ExcludedEC2ResourceType:
         default: Is EC2 Resource Type Excluded?
       ExcludedLambdaResourceType:
@@ -267,6 +270,10 @@ Parameters:
     Description: Failure notification email address
     MaxLength: 320
     Default: ""
+  SnsKmsKeyArn:
+    Type: String
+    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Default: ""
   CreateSecret:
     Type: String
     Description: Set to False In case you want to use secrets manager with a predefine secret that was already created and contains Coralogix Send Your Data API key.
@@ -309,6 +316,11 @@ Conditions:
     Fn::Not:
       - Fn::Equals:
           - Ref: NotificationEmail
+          - ""
+  IsSnsKmsKeySet:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: SnsKmsKeyArn
           - ""
   IsSMEnabled:
     Fn::Not:
@@ -355,6 +367,13 @@ Conditions:
   CrossAccountHasOrgId: !Not [!Equals [!Ref OrganizationId, ""]]
 
 Resources:
+  FailureNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
   MetadataQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -446,6 +465,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Policies:
         - !If
           - IsNotEC2ResourceTypeExcluded
@@ -506,6 +526,17 @@ Resources:
                 Action: sts:AssumeRole
                 Resource: !Ref ConfigCrossAccountRole
           - !Ref 'AWS::NoValue'
+        - !If
+          - IsSnsKmsKeySet
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+          - !Ref AWS::NoValue
 
   CollectorLambdaFunctionNotificationSubscription:
     Type: AWS::SNS::Subscription
@@ -514,7 +545,7 @@ Resources:
       Protocol: email
       Endpoint:
         Ref: NotificationEmail
-      TopicArn: !Ref CollectorLambdaFunction.DestinationTopic
+      TopicArn: !Ref FailureNotificationTopic
 
   GeneratorLambdaFunction:
     Condition: IsNotSMEnabled
@@ -568,6 +599,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -613,6 +645,17 @@ Resources:
                 Action: sts:AssumeRole
                 Resource: !Sub "arn:aws:iam::*:role/${CrossAccountIAMRoleName}"
           - !Ref 'AWS::NoValue'
+        - !If
+          - IsSnsKmsKeySet
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+          - !Ref AWS::NoValue
 
   GeneratorLambdaFunctionSM:
     Condition: IsSMEnabled
@@ -671,6 +714,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -717,6 +761,17 @@ Resources:
                 Resource: !Sub "arn:aws:iam::*:role/${CrossAccountIAMRoleName}"
           - !Ref 'AWS::NoValue'
         - SecretsManagerReadWrite
+        - !If
+          - IsSnsKmsKeySet
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+          - !Ref AWS::NoValue
 
   PrivateKeySecret:
     Condition: CreateSecret
@@ -735,11 +790,7 @@ Resources:
       Protocol: email
       Endpoint:
         Ref: NotificationEmail
-      TopicArn:
-        !If
-          - IsSMEnabled
-          - !Ref GeneratorLambdaFunctionSM.DestinationTopic
-          - !Ref GeneratorLambdaFunction.DestinationTopic
+      TopicArn: !Ref FailureNotificationTopic
 
   CloudTrailBucket:
     Type: AWS::S3::Bucket

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -784,15 +784,6 @@ Resources:
         - function: !Ref GeneratorLambdaFunctionSM
       SecretString: !Ref ApiKey
 
-  GeneratorLambdaFunctionNotificationSubscription:
-    Type: AWS::SNS::Subscription
-    Condition: IsNotificationEnabled
-    Properties:
-      Protocol: email
-      Endpoint:
-        Ref: NotificationEmail
-      TopicArn: !Ref FailureNotificationTopic
-
   CloudTrailBucket:
     Type: AWS::S3::Bucket
     Condition: EventModeCreateTrail

--- a/src/resource-metadata-sqs/template.yaml
+++ b/src/resource-metadata-sqs/template.yaml
@@ -368,7 +368,23 @@ Conditions:
   CrossAccountHasOrgId: !Not [!Equals [!Ref OrganizationId, ""]]
 
 Resources:
-  FailureNotificationTopic:
+  CollectorLambdaFunctionEventInvokeConfigOnFailureTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
+  GeneratorLambdaFunctionEventInvokeConfigOnFailureTopic:
+    Condition: IsNotSMEnabled
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
+  GeneratorLambdaFunctionSMEventInvokeConfigOnFailureTopic:
+    Condition: IsSMEnabled
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: !If
@@ -466,7 +482,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref CollectorLambdaFunctionEventInvokeConfigOnFailureTopic
       Policies:
         - !If
           - IsNotEC2ResourceTypeExcluded
@@ -546,7 +562,7 @@ Resources:
       Protocol: email
       Endpoint:
         Ref: NotificationEmail
-      TopicArn: !Ref FailureNotificationTopic
+      TopicArn: !Ref CollectorLambdaFunctionEventInvokeConfigOnFailureTopic
 
   GeneratorLambdaFunction:
     Condition: IsNotSMEnabled
@@ -600,7 +616,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref GeneratorLambdaFunctionEventInvokeConfigOnFailureTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -715,7 +731,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref GeneratorLambdaFunctionSMEventInvokeConfigOnFailureTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -783,6 +799,18 @@ Resources:
         - 'lambda/coralogix/${AWS::Region}/${function}'
         - function: !Ref GeneratorLambdaFunctionSM
       SecretString: !Ref ApiKey
+
+  GeneratorLambdaFunctionNotificationSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: IsNotificationEnabled
+    Properties:
+      Protocol: email
+      Endpoint:
+        Ref: NotificationEmail
+      TopicArn: !If
+        - IsSMEnabled
+        - !Ref GeneratorLambdaFunctionSMEventInvokeConfigOnFailureTopic
+        - !Ref GeneratorLambdaFunctionEventInvokeConfigOnFailureTopic
 
   CloudTrailBucket:
     Type: AWS::S3::Bucket

--- a/src/resource-metadata/CHANGELOG.md
+++ b/src/resource-metadata/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This format is based on Keep a Changelog.
 
+## [1.2.13] - 2026-08-13
+### Added
+- Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+
 ## [1.2.12] - 2025-12-04
 ### Changed
 - Update the Node.js runtime to 22.x.

--- a/src/resource-metadata/CHANGELOG.md
+++ b/src/resource-metadata/CHANGELOG.md
@@ -6,6 +6,8 @@ This format is based on Keep a Changelog.
 ## [1.2.13] - 2026-08-13
 ### Added
 - Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+### Fixed
+- Reuse the SAM OnFailure topic logical IDs so existing email subscriptions are not replaced when `SnsKmsKeyArn` is unset.
 
 ## [1.2.12] - 2025-12-04
 ### Changed

--- a/src/resource-metadata/README.md
+++ b/src/resource-metadata/README.md
@@ -30,6 +30,7 @@ This application collect AWS resource metadata and sends them to your **Coralogi
 | Schedule | Collect metadata on a specific schedule. | rate(10 minutes) | |
 | LayerARN | In case you want to use Secret Manager This is the ARN of the Coralogix [lambda layer](https://serverlessrepo.aws.amazon.com/applications/eu-central-1/597078901540/Coralogix-Lambda-SSMLayer). | | |
 | NotificationEmail | If the lambda fails a notification email will be sent to this address via SNS (requires you have a working SNS, with a validated domain). | | |
+| SnsKmsKeyArn | Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
 | FunctionArchitecture | Lambda function architecture, possible options are [x86_64, arm64]. | x86_64 | |
 | FunctionMemorySize | The maximum allocated memory this lambda may consume. Default value is the minimum recommended setting please consult coralogix support before changing. | 256 | |
 | FunctionTimeout | The maximum time in seconds the function may be allowed to run. Default value is the minimum recommended setting please consult coralogix support before changing. | 300 | |

--- a/src/resource-metadata/README.md
+++ b/src/resource-metadata/README.md
@@ -30,7 +30,7 @@ This application collect AWS resource metadata and sends them to your **Coralogi
 | Schedule | Collect metadata on a specific schedule. | rate(10 minutes) | |
 | LayerARN | In case you want to use Secret Manager This is the ARN of the Coralogix [lambda layer](https://serverlessrepo.aws.amazon.com/applications/eu-central-1/597078901540/Coralogix-Lambda-SSMLayer). | | |
 | NotificationEmail | If the lambda fails a notification email will be sent to this address via SNS (requires you have a working SNS, with a validated domain). | | |
-| SnsKmsKeyArn | Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
+| SnsKmsKeyArn | Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`. | | |
 | FunctionArchitecture | Lambda function architecture, possible options are [x86_64, arm64]. | x86_64 | |
 | FunctionMemorySize | The maximum allocated memory this lambda may consume. Default value is the minimum recommended setting please consult coralogix support before changing. | 256 | |
 | FunctionTimeout | The maximum time in seconds the function may be allowed to run. Default value is the minimum recommended setting please consult coralogix support before changing. | 300 | |

--- a/src/resource-metadata/template.yaml
+++ b/src/resource-metadata/template.yaml
@@ -167,7 +167,8 @@ Parameters:
     Default: ""
   SnsKmsKeyArn:
     Type: String
-    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Description: Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    AllowedPattern: '^$|^arn:[a-z0-9-]+:kms:[a-z0-9-]+:[0-9]{12}:key/.+$'
     Default: ""
   CreateSecret:
     Type: String

--- a/src/resource-metadata/template.yaml
+++ b/src/resource-metadata/template.yaml
@@ -13,7 +13,7 @@ Metadata:
       - coralogix
       - metadata
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.2.12
+    SemanticVersion: 1.2.13
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-serverless
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -34,6 +34,7 @@ Metadata:
           - LambdaFunctionExcludeRegexFilter
           - LambdaFunctionTagFilters
           - NotificationEmail
+          - SnsKmsKeyArn
           - ExcludedEC2ResourceType
           - ExcludedLambdaResourceType
       - Label:
@@ -78,6 +79,8 @@ Metadata:
         default: Timeout
       NotificationEmail:
         default: Notification Email
+      SnsKmsKeyArn:
+        default: SNS KMS Key ARN
       ExcludedEC2ResourceType:
         default: Is EC2 Resource Type Excluded?
       ExcludedLambdaResourceType:
@@ -162,6 +165,10 @@ Parameters:
     Description: Failure notification email address
     MaxLength: 320
     Default: ""
+  SnsKmsKeyArn:
+    Type: String
+    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Default: ""
   CreateSecret:
     Type: String
     Description: Set to False In case you want to use secrets manager with a predefine secret that was already created and contains Coralogix Send Your Data API key.
@@ -205,6 +212,11 @@ Conditions:
       - Fn::Equals:
           - Ref: NotificationEmail
           - ""
+  IsSnsKmsKeySet:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: SnsKmsKeyArn
+          - ""
   IsSMEnabled:
     Fn::Not:
       - Fn::Equals:
@@ -241,6 +253,13 @@ Conditions:
       - Ref: ExcludedLambdaResourceType
       - 'False'
 Resources:
+  FailureNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
   LambdaFunction:
     Condition: IsNotSMEnabled
     Type: AWS::Serverless::Function
@@ -300,6 +319,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -333,6 +353,17 @@ Resources:
               Action:
                 - tag:GetResources
               Resource: "*"
+        - !If
+          - IsSnsKmsKeySet
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+          - !Ref AWS::NoValue
   LambdaFunctionSM:
     Condition: IsSMEnabled
     Type: AWS::Serverless::Function
@@ -397,6 +428,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -431,6 +463,17 @@ Resources:
                 - tag:GetResources
               Resource: "*"
         - SecretsManagerReadWrite
+        - !If
+          - IsSnsKmsKeySet
+          - Version: "2012-10-17"
+            Statement:
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+          - !Ref AWS::NoValue
 
   PrivateKeySecret:
     Condition: CreateSecret
@@ -449,8 +492,4 @@ Resources:
       Protocol: email
       Endpoint:
         Ref: NotificationEmail
-      TopicArn:
-        !If
-          - IsSMEnabled
-          - !Ref LambdaFunctionSM.DestinationTopic
-          - !Ref LambdaFunction.DestinationTopic
+      TopicArn: !Ref FailureNotificationTopic

--- a/src/resource-metadata/template.yaml
+++ b/src/resource-metadata/template.yaml
@@ -254,7 +254,16 @@ Conditions:
       - Ref: ExcludedLambdaResourceType
       - 'False'
 Resources:
-  FailureNotificationTopic:
+  LambdaFunctionEventInvokeConfigOnFailureTopic:
+    Condition: IsNotSMEnabled
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
+  LambdaFunctionSMEventInvokeConfigOnFailureTopic:
+    Condition: IsSMEnabled
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: !If
@@ -320,7 +329,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref LambdaFunctionEventInvokeConfigOnFailureTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -429,7 +438,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref LambdaFunctionSMEventInvokeConfigOnFailureTopic
       Policies:
         - !If 
           - IsNotEC2ResourceTypeExcluded
@@ -493,4 +502,7 @@ Resources:
       Protocol: email
       Endpoint:
         Ref: NotificationEmail
-      TopicArn: !Ref FailureNotificationTopic
+      TopicArn: !If
+        - IsSMEnabled
+        - !Ref LambdaFunctionSMEventInvokeConfigOnFailureTopic
+        - !Ref LambdaFunctionEventInvokeConfigOnFailureTopic

--- a/src/sf-eventlog/CHANGELOG.md
+++ b/src/sf-eventlog/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This format is based on Keep a Changelog.
 
+## [1.0.4] - 2026-08-13
+### Added
+- Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+
 ## [1.0.3] - 2023-08-09
 ### Fixed
 - Fix the Salesforce API update flow.

--- a/src/sf-eventlog/CHANGELOG.md
+++ b/src/sf-eventlog/CHANGELOG.md
@@ -6,6 +6,8 @@ This format is based on Keep a Changelog.
 ## [1.0.4] - 2026-08-13
 ### Added
 - Add optional `SnsKmsKeyArn` to encrypt the Lambda failure-notification SNS topic with a customer-managed KMS key.
+### Fixed
+- Reuse the SAM OnFailure topic logical ID so existing email subscriptions are not replaced when `SnsKmsKeyArn` is unset.
 
 ## [1.0.3] - 2023-08-09
 ### Fixed

--- a/src/sf-eventlog/README.md
+++ b/src/sf-eventlog/README.md
@@ -29,6 +29,7 @@ To learn more about application name and subsystem name go [here](https://coralo
 * **FunctionTimeout** - Lambda function timeout limit.
 * **FunctionSchedule** - Lambda function schedule in hours, the function will be invoked each X hours. after deploy first invocation will be after X hours.
 * **NotificationEmail** - Failure notification email address.
+* **SnsKmsKeyArn** - Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`.
 
 ## Script Configuration
 

--- a/src/sf-eventlog/README.md
+++ b/src/sf-eventlog/README.md
@@ -29,7 +29,7 @@ To learn more about application name and subsystem name go [here](https://coralo
 * **FunctionTimeout** - Lambda function timeout limit.
 * **FunctionSchedule** - Lambda function schedule in hours, the function will be invoked each X hours. after deploy first invocation will be after X hours.
 * **NotificationEmail** - Failure notification email address.
-* **SnsKmsKeyArn** - Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`.
+* **SnsKmsKeyArn** - Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow `sns.amazonaws.com` and the Lambda execution role to use `kms:Decrypt` and `kms:GenerateDataKey*`.
 
 ## Script Configuration
 

--- a/src/sf-eventlog/template.yaml
+++ b/src/sf-eventlog/template.yaml
@@ -15,7 +15,7 @@ Metadata:
       - logs
       - event-log
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.0.3
+    SemanticVersion: 1.0.4
     SourceCodeUrl: "https://github.com/coralogix/coralogix-aws-serverless"
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -44,6 +44,7 @@ Metadata:
           - FunctionTimeout
           - FunctionSchedule
           - NotificationEmail
+          - SnsKmsKeyArn
       - Label:
           default: Script Configuration
         Parameters:
@@ -168,6 +169,10 @@ Parameters:
     Description: Failure notification email address
     MaxLength: 320
     Default: ""
+  SnsKmsKeyArn:
+    Type: String
+    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Default: ""
   LogsToStdout:
     Type: String
     Description: Send logs to stdout/cloudwatch [True,False]
@@ -194,7 +199,15 @@ Conditions:
     - !Equals
       - !Ref NotificationEmail
       - ''
+  IsSnsKmsKeySet: !Not [!Equals [!Ref SnsKmsKeyArn, '']]
 Resources:
+  FailureNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !If
+        - IsSnsKmsKeySet
+        - !Ref SnsKmsKeyArn
+        - !Ref AWS::NoValue
   DynamoDB:
     Type: AWS::Serverless::SimpleTable
     Properties:
@@ -249,10 +262,22 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
+            Destination: !Ref FailureNotificationTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName:
               Ref: DynamoDB
+        - !If
+          - IsSnsKmsKeySet
+          - Version: '2012-10-17'
+            Statement:
+              - Sid: SnsKms
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                Resource: !Ref SnsKmsKeyArn
+          - !Ref AWS::NoValue
       Events:
         CWSchedule:
           Type: Schedule
@@ -271,4 +296,4 @@ Resources:
       Endpoint:
         Ref: NotificationEmail
       TopicArn:
-        Ref: LambdaFunction.DestinationTopic
+        Ref: FailureNotificationTopic

--- a/src/sf-eventlog/template.yaml
+++ b/src/sf-eventlog/template.yaml
@@ -202,7 +202,7 @@ Conditions:
       - ''
   IsSnsKmsKeySet: !Not [!Equals [!Ref SnsKmsKeyArn, '']]
 Resources:
-  FailureNotificationTopic:
+  LambdaFunctionEventInvokeConfigOnFailureTopic:
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: !If
@@ -263,7 +263,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-            Destination: !Ref FailureNotificationTopic
+            Destination: !Ref LambdaFunctionEventInvokeConfigOnFailureTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName:
@@ -297,4 +297,4 @@ Resources:
       Endpoint:
         Ref: NotificationEmail
       TopicArn:
-        Ref: FailureNotificationTopic
+        Ref: LambdaFunctionEventInvokeConfigOnFailureTopic

--- a/src/sf-eventlog/template.yaml
+++ b/src/sf-eventlog/template.yaml
@@ -171,7 +171,8 @@ Parameters:
     Default: ""
   SnsKmsKeyArn:
     Type: String
-    Description: Optional KMS key ARN or alias to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    Description: Optional KMS key ARN (not an alias) to encrypt the Lambda failure-notification SNS topic. Leave empty for no encryption. The key policy must allow sns.amazonaws.com and the Lambda execution role to use kms:Decrypt and kms:GenerateDataKey*.
+    AllowedPattern: '^$|^arn:[a-z0-9-]+:kms:[a-z0-9-]+:[0-9]{12}:key/.+$'
     Default: ""
   LogsToStdout:
     Type: String


### PR DESCRIPTION
# Description

Allow a customer-managed KMS key on the OnFailure SNS topic; leave unset to keep today's unencrypted behavior. Fixes CDS-2402.

# How Has This Been Tested?

In AWS account.

# Checklist:
- [x] I have updated the versions in the changed module in the template index.js and package.json files.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect module (e.g. it's readme file change)